### PR TITLE
Changed single-line blocks to be acceptable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,10 +582,10 @@
 
 ## <a name='blocks'>Blocks</a>
 
-  - Use braces with blocks and always on multiple lines.
+  - Use braces with all multi-line blocks.
 
     ```javascript
-    // bad
+    // good
     if (test) return false;
 
     // good
@@ -594,12 +594,8 @@
     }
 
     // bad
-    function() { return false; }
-
-    // good
-    function() {
+    if (test)
       return false;
-    }
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
I think single-line blocks are great, and I use them all the time. They're very readable -- more so than braced-single-statement blocks, in my opinion -- and I don't think they're "dangerous" in the Crockford sense, because if it's on a single line it's obvious what's part of the block and what isn't.

For example, I think it's pretty clear in the following that `console.log` will always be called:

``` javascript
var volume = 10;
if(louder) volume = 11;
console.log(volume);
```

On the other hand, I _do_ think that multi-line blocks without braces are dangerous. For example, this is very confusing:

``` javascript
var volume = 10;
if(louder)
  volume = 12;
  console.log(volume);
```

So I left multi-line blocks as needing curly braces.
