### PR TITLE
Switched modules to bang-style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,6 +1085,7 @@
 
 ## <a name='modules'>Modules</a>
 
+  - The module should start with a `!`. This ensures that if a malformed module forgets to include a final semicolon there aren't errors in production when the scripts get concatenated.
   - The file should be named with camelCase, live in a folder with the same name, and match the name of the single export.
   - Add a method called noConflict() that sets the exported module to the previous version.
   - Always declare `'use strict;'` at the top of the module.
@@ -1092,7 +1093,7 @@
     ```javascript
     // fancyInput/fancyInput.js
 
-    (function(global) {
+    !function(global) {
       'use strict';
 
       var previousFancyInput = global.FancyInput;
@@ -1106,7 +1107,7 @@
       };
 
       global.FancyInput = FancyInput;
-    })(this);
+    }(this);
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
I propose writing modules like this:

``` javascript
!function() {
}();
```

This saves us from a problem that has bitten us in the past, where the following modules work in dev:

``` javascript
// Module A
(function() {
}())
```

``` javascript
// Module B
(function() {
}());
```

But blow up in production when the two files get concatenated (note the missing semicolon in Module A). Starting modules with bang (lol) is the shortest possible way to prevent this; ASI will kick in because of the bang and prevent the module from being incorrectly interpreted as arguments to a function call.
