### PR TITLE
SublimeLinter updates

### DIFF
--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -7,7 +7,7 @@
  *   3. Paste the contents of this file into your settings file
  *   4. Save the settings file
  *
- * @version 0.1.1
+ * @version 0.2.0
  * @see     https://github.com/SublimeLinter/SublimeLinter
  * @see     http://www.jshint.com/docs/
  */


### PR DESCRIPTION
This enforces `camelCase` or `UPPER_CASE_UNDERSCORE` for all variables like mentioned in the README. Constructor functions still require `UpperCase` with the `newcap` setting.
