### PR TITLE
Define globals exposed by Node.js

### DIFF
--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -25,6 +25,9 @@
       // Defines globals exposed by jQuery.
       "jquery": true,
 
+      // Define globals exposed by Node.js.
+      "node": true,
+
       /*
        * ENFORCING OPTIONS
        * =================


### PR DESCRIPTION
This makes JSHint a lot less noisy when developing for Node.
