### PR TITLE
Enforce single quotes

### DIFF
--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -7,7 +7,7 @@
  *   3. Paste the contents of this file into your settings file
  *   4. Save the settings file
  *
- * @version 0.2.0
+ * @version 0.3.0
  * @see     https://github.com/SublimeLinter/SublimeLinter
  * @see     http://www.jshint.com/docs/
  */


### PR DESCRIPTION
As described in the [strings](https://github.com/airbnb/javascript#strings) section, we want single quotes for all strings. JSHint has a setting to enforce it, which is added by this pull request.
