### PR TITLE
variable declaration to newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@
     var items = getItems(),
         goSportsTeam = true,
         dragonball,
-        i, length;
+        i, 
+        length;
     ```
 
   - Assign variables at the top of their scope. This helps avoid issues with variable declaration and assignment hoisting related issues.


### PR DESCRIPTION
On the third variables example, I moved the length declaration to its own line to follow the previous guideline.
