### PR TITLE
[tools] add tools section, add sublime snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   1. [ES5 Compatibility](#es5)
   1. [Testing](#testing)
   1. [Performance](#performance)
+  1. [Tools](#tools)
   1. [Resources](#resources)
   1. [In the Wild](#in-the-wild)
   1. [Translation](#translation)
@@ -1282,6 +1283,16 @@
 
   **[[⬆]](#TOC)**
 
+
+## <a name='Tools'>Tools</a>
+
+**Linters**
+
+  - [SublimeLinter](https://github.com/airbnb/javascript/tree/master/linters/SublimeLinter)
+
+**Snippets**
+
+  - [Sublime](https://github.com/airbnb/javascript/tree/master/snippets/sublime/javascript)
 
 ## <a name='resources'>Resources</a>
 

--- a/snippets/sublime/README.md
+++ b/snippets/sublime/README.md
@@ -1,0 +1,143 @@
+# Sublime Text Snippets
+
+Keyboard Karate that matches our [mostly reasonable approach to JavaScript](https://github.com/airbnb/javascript)
+
+## Installation
+
+Move the `javascript` folder to `~/Library/Application Support/Sublime Text 2/Packages/User/`
+
+## Guide
+
+Sublime Text snippets work when you type some letters (let's call them commands), then you hit `enter` to insert the snippet. Then additional `tabs` will move your cursor to the next anchor point. Anchor points are illustrated in this guide as sequential number counts. `1` is where the cursor will start, pressing `tab` will take you to `2` and so on.
+
+## <a name='TOC'>Table of Contents</a>
+
+  1. [vo](#vo): var object
+  1. [va](#va): var array
+  1. [vs](#vs): var string
+  1. [if](#if): if statement
+  1. [ife](#ife): if/else statement
+  1. [whi](#whi): while loop
+  1. [vf](#vf): var function
+  1. [af](#af): anonymous function
+  1. [nf](#nf): named function
+  1. [pf](#pf): property function
+  1. [iife](#iife): immediately invoked function expression
+  1. [mod](#mod): module
+  1. [args](#args): arguments array
+  1. [tr](#tr): `this` reference
+  1. [con](#con): console.log
+
+
+
+## <a name='vo'>`vo`</a>
+
+```javascript
+var 1 = {2};
+```
+
+## <a name='va'>`va`</a>
+
+```javascript
+var 1 = [2];
+```
+
+## <a name='vs'>`vs`</a>
+
+```javascript
+var 1 = '2';
+```
+
+## <a name='if'>`if`</a>
+
+```javascript
+if (1) {
+  2
+}
+```
+
+## <a name='ife'>`ife`</a>
+
+```javascript
+if (1) {
+  2
+} else {
+  3
+}
+```
+
+## <a name='whi'>`whi`</a>
+
+```javascript
+while (1) {
+  2
+}
+```
+
+## <a name='vf'>`vf`</a>
+
+```javascript
+var 1 = function2() {
+  3
+};
+```
+
+## <a name='af'>`af`</a>
+
+```javascript
+function(1) {
+  2
+}3
+```
+
+## <a name='nf'>`nf`</a>
+
+```javascript
+function 1(2) {
+  3
+}4
+```
+
+## <a name='pf'>`pf`</a>
+
+```javascript
+1: function(2) {
+  3
+}4
+```
+
+## <a name='iife'>`iife`</a>
+
+```javascript
+(function(1) {
+  2
+})(3);
+```
+
+## <a name='mod'>`mod`</a>
+
+```javascript
+!function() {
+  'use strict';
+
+  1
+}();
+```
+
+## <a name='args'>`args`</a>
+
+```javascript
+var args = Array.prototype.slice.apply(arguments);
+```
+
+## <a name='tr'>`tr`</a>
+
+```javascript
+var _this = this;
+```
+
+## <a name='con'>`con`</a>
+
+```javascript
+console.log(1);
+```

--- a/snippets/sublime/javascript/Backbone/defaults-hash.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/defaults-hash.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+defaults: {
+  '${1}': '${2}',
+},
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>bd</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/events-hash.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/events-hash.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+events: {
+  '${1}': '${2}',
+},
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>be</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/extend-collection.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/extend-collection.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+${1}Collection = Backbone.Collection.extend({
+  ${2}
+});
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>bc</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/extend-model.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/extend-model.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+${1}Model = Backbone.Model.extend({
+  ${2}
+});
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>bm</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/extend-view-initialize.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/extend-view-initialize.sublime-snippet
@@ -1,0 +1,17 @@
+<snippet>
+  <content><![CDATA[
+${1}View = Backbone.View.extend({
+  initialize: function() {
+    ${2}
+  },
+
+  render: function() {
+    ${3}
+  }
+});
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>bvi</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/extend-view.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/extend-view.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+  <content><![CDATA[
+${1}View = Backbone.View.extend({
+  ${2}
+});
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>bv</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/initialize-function.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/initialize-function.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+initialize: function() {
+  ${1}  
+},
+${2}
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>inf</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/module.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/module.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+  <content><![CDATA[
+(function(){
+  'use strict';
+
+  ${1}
+})();
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>module</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/Backbone/new-collection.sublime-snippet
+++ b/snippets/sublime/javascript/Backbone/new-collection.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+  <content><![CDATA[
+${1}Collection = new Backbone.Collection(${2});
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>nbc</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <!-- <scope>source.python</scope> -->
+</snippet>

--- a/snippets/sublime/javascript/anonymous-function.sublime-snippet
+++ b/snippets/sublime/javascript/anonymous-function.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+function(${1}) {
+  ${2}
+}${3}
+]]></content>
+  <tabTrigger>af</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/arguments-array.sublime-snippet
+++ b/snippets/sublime/javascript/arguments-array.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+var args = Array.prototype.slice.apply(arguments);
+]]></content>
+  <tabTrigger>args</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/console-log.sublime-snippet
+++ b/snippets/sublime/javascript/console-log.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+console.log(${1});
+]]></content>
+  <tabTrigger>cl</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/if-else.sublime-snippet
+++ b/snippets/sublime/javascript/if-else.sublime-snippet
@@ -1,0 +1,10 @@
+<snippet>
+  <content><![CDATA[
+if (${1}) {
+  ${2}
+} else {
+  ${3}
+}
+]]></content>
+  <tabTrigger>ife</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/if.sublime-snippet
+++ b/snippets/sublime/javascript/if.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+if (${1}) {
+  ${2}
+}
+]]></content>
+  <tabTrigger>if</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/iife.sublime-snippet
+++ b/snippets/sublime/javascript/iife.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+(function(${1}){
+  ${2}
+})(${3});
+]]></content>
+  <tabTrigger>iife</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/module.sublime-snippet
+++ b/snippets/sublime/javascript/module.sublime-snippet
@@ -1,0 +1,10 @@
+<snippet>
+  <content><![CDATA[
+!function(){
+  'use strict';
+
+  ${1}
+}();
+]]></content>
+  <tabTrigger>mod</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/named-function.sublime-snippet
+++ b/snippets/sublime/javascript/named-function.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+function ${1}(${2}) {
+  ${3}
+}${4}
+]]></content>
+  <tabTrigger>nf</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/property-function.sublime-snippet
+++ b/snippets/sublime/javascript/property-function.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+${1}: function(${2}) {
+  ${3}
+}${4}
+]]></content>
+  <tabTrigger>pf</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/this-reference.sublime-snippet
+++ b/snippets/sublime/javascript/this-reference.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+var _this = this;
+]]></content>
+  <tabTrigger>tr</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/var-array.sublime-snippet
+++ b/snippets/sublime/javascript/var-array.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+var ${1} = [${2}];
+]]></content>
+  <tabTrigger>va</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/var-function.sublime-snippet
+++ b/snippets/sublime/javascript/var-function.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+var ${1} = function${2}() {
+  ${3}
+};
+]]></content>
+  <tabTrigger>vf</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/var-object.sublime-snippet
+++ b/snippets/sublime/javascript/var-object.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+var ${1} = {${2}};
+]]></content>
+  <tabTrigger>vo</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/var-string.sublime-snippet
+++ b/snippets/sublime/javascript/var-string.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[
+var ${1} = '${2}';
+]]></content>
+  <tabTrigger>vo</tabTrigger>
+</snippet>

--- a/snippets/sublime/javascript/while.sublime-snippet
+++ b/snippets/sublime/javascript/while.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[
+while (${1}) {
+  ${2}
+}
+]]></content>
+  <tabTrigger>whi</tabTrigger>
+</snippet>


### PR DESCRIPTION
Made some sublime snippets for quick shortcut aliases. They match the style guide and are fun to use.

Does it make sense to include these in the style guide repo? I was thinking it would fit with the way we include the [SublimeLinter](https://github.com/airbnb/javascript/tree/master/linters/SublimeLinter) in the linters directory.
