### PR TITLE
Fixed small error in jQuery selector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,7 +1249,7 @@
     }
     ```
 
-  - For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > .ul')`. [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
+  - For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > ul')`. [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
   - Use `find` with scoped jQuery object queries.
 
     ```javascript


### PR DESCRIPTION
Really small fix :

```
$('.sidebar > ul') instead of $('.sidebar > .ul')
```

Thanks for this great guide !
