### PR TITLE
Change Array.prototype.slice.call(items) to items.slice()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@
     }
 
     // good
-    itemsCopy = Array.prototype.slice.call(items);
+    itemsCopy = items.slice();
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
`items.slice()` does the same thing as `Array.prototype.slice.call(items)`, in fact, it even calls `prototype.slice` implicitly, but it's faster.
