### PR TITLE
IIFE changed to Crockford's prefered format

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,14 +775,14 @@
     // bad
     (function(global) {
       // ...stuff...
-    })(this);
+    }(this));
     ```
 
     ```javascript
     // good
     (function(global) {
       // ...stuff...
-    })(this);
+    }(this));
 
     ```
 
@@ -891,19 +891,19 @@
     (function() {
       var name = 'Skywalker'
       return name
-    })()
+    }())
 
     // good
     (function() {
       var name = 'Skywalker';
       return name;
-    })();
+    }());
 
     // good
     ;(function() {
       var name = 'Skywalker';
       return name;
-    })();
+    }());
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
IIFE changed to Crockford's prefered format.

The first parenthesis is a marker for an IIFE and there is no need to call the function only for let JavaScript know it will be called immediately.

Some linter warns for it like jshint (http://www.jslint.com/).
"Move the invocation into the parens that contain the function."

Function Declarations  part of http://javascript.crockford.com/code.html
