### PR TITLE
Fix jQuery selector with context param order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,7 +1343,7 @@
 
     ```javascript
     // bad
-    $('.sidebar', 'ul').hide();
+    $('ul', '.sidebar').hide();
 
     // bad
     $('.sidebar').find('ul').hide();


### PR DESCRIPTION
`$('.sidebar', 'ul')` is looking for all `.sidebar` within `ul`, where the rest of the examples are `ul` within `.sidebar`

Flipped it to match rest of the examples
