### PR TITLE
removing the attachment to the 'this' object of the private variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,15 +1044,15 @@
     });
     ```
 
-  - Use a leading underscore `_` when naming private properties
+  - Use a leading underscore `_` when naming private properties ([When a member is private?](http://javascript.crockford.com/private.html))
 
     ```javascript
     // bad
-    this.__firstName__ = 'Panda';
-    this.firstName_ = 'Panda';
+    var __firstName__ = 'Panda';
+    var firstName_ = 'Panda';
 
     // good
-    this._firstName = 'Panda';
+    var _firstName = 'Panda';
     ```
 
   - When saving a reference to `this` use `_this`.


### PR DESCRIPTION
Hi @hshoff,
Don't you think that binding a private variable to the this object makes the variable/property be public? Although the name makes it obscured, a new team member could access to these members and change them directly. It'd be better to deny that possibility.
http://javascript.crockford.com/private.html
