### PR TITLE
Remove invalid name - Naming Conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,6 @@
     // bad
     var OBJEcttsssss = {};
     var this_is_my_object = {};
-    var this-is-my-object = {};
     function c() {};
     var u = new user({
       name: 'Bob Parr'


### PR DESCRIPTION
In naming conventions `var this-is-my-object = {};` is given as an example of a bad name. But this is an invalid name in Javascript. I dont think it is needed since its a syntax error and an invalid name in the first place.
