### PR TITLE
Update SublimeLinter.sublime-settings to include maxlen enforcement 

### DIFF
--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -62,6 +62,9 @@
       "undef": true,
 
       // Warn when variables are defined but never used.
-      "unused": true
+      "unused": true,
+      
+      // Enforce line length to 80 characters
+      "maxlen": 80
     }
 }


### PR DESCRIPTION
The Airbnb guide states: "Strings longer than 80 characters should be written across multiple lines using string concatenation."

I propose to add the maxlen option to enforce this rule: http://www.jshint.com/docs/options/#maxlen

However maxlen enforces the entire source code, not just a line of String. I would like to hear your thoughts on whether that is a beneficial enforcement to keep JS code at a set width.
