### PR TITLE
Add a missing `.hide()` for consistency's sake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,7 +1368,7 @@
     $('.sidebar > ul').hide();
 
     // good
-    $sidebar.find('ul');
+    $sidebar.find('ul').hide();
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
The section about jQuery suggests different ways of finding an element, and in all of the examples the selected element is `.hide()`-ed. Except the last example, for some reason. Assuming it was a mistake to not call `.hide()` on that last one, I've fixed the discrepancy.
