### PR TITLE
Enforce 'use strict'

### DIFF
--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -65,6 +65,9 @@
       "unused": true,
       
       // Enforce line length to 80 characters
-      "maxlen": 80
+      "maxlen": 80,
+
+      // Enforce placing 'use strict' at the top function scope
+      "strict": true
     }
 }


### PR DESCRIPTION
As stated in the [Modules section](https://github.com/airbnb/javascript#modules), `'use strict'` needs to be declared at the top of a module

[JSHint has an option](http://www.jshint.com/docs/options/#strict) for something like this by enforcing the declaration of `'use strict'` at the top function scope.
