### PR TITLE
Add .jshintrc

### DIFF
--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -1,0 +1,57 @@
+{
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": true,
+
+  // Define globals exposed by jQuery.
+  "jquery": true,
+
+  // Define globals exposed by Node.js.
+  "node": true,
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Prohibit trailing whitespace.
+  "trailing": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  // Enforce line length to 80 characters
+  "maxlen": 80,
+
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true
+}


### PR DESCRIPTION
This adds a `.jshintrc` to the `linters/` directory. I just copied over
the settings from the `SublimeLinter` file, de-nesting the JSON object
by one level.

It means we'll have to maintain both files, but it's good to have a
basic `.jshintrc` for those of us that aren't using JSHint through
Sublime Text.

As requested in https://github.com/airbnb/rendr/pull/239.

@hshoff what do you think?
