### PR TITLE
[DO NOT MERGE!] Different way of declaring variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,18 +368,18 @@
     var superPower = new SuperPower();
     ```
 
-  - Use one `var` declaration for multiple variables and declare each variable on a newline.
+  - Use one `var` declaration for each declared variable.
 
     ```javascript
     // bad
-    var items = getItems();
-    var goSportsTeam = true;
-    var dragonball = 'z';
-
-    // good
     var items = getItems(),
         goSportsTeam = true,
         dragonball = 'z';
+
+    // good
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball = 'z';
     ```
 
   - Declare unassigned variables last. This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.


### PR DESCRIPTION
What if we move away from declaring all variables with one `var` to using one `var` per variable?
It reads better (no need to argue on how to indent 2nd and further lines) and it's not our job to optimise code manually.

Any thoughts?
