### PR TITLE
Remove unnecessary extra newline that confused some markdown previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@
     ```javascript
     var someStack = [];
 
-
     // bad
     someStack[someStack.length] = 'abracadabra';
 


### PR DESCRIPTION
The markdown previewer for Atom.io didn't like the double newline inside the code block, it treated it as 2 separate code blocks (which threw out formatting for the rest of the file).

Github seems to handle it, but the extra newline seemed redundant anyway.
