### PR TITLE
Note in the Objects and Arrays section on avoiding trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@
     };
     ```
 
+  - Avoid trailing commas in object initialization - see [Commas](#commas).
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Arrays
@@ -169,6 +171,8 @@
       ...
     }
     ```
+
+  - Avoid trailing commas in array initialization - see [Commas](#commas).
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Note in the Objects and Arrays section on avoiding trailing commas with a link to the Commas section.