### PR TITLE
Some additional notes on naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,7 +995,7 @@
 
 ## Naming Conventions
 
-  - Avoid single letter names. Be descriptive with your naming.
+  - Avoid single letter names. Be descriptive with your naming. Names representing types should be nouns. Names representing methods should be verbs or verb phrases.
 
     ```javascript
     // bad
@@ -1009,7 +1009,7 @@
     }
     ```
 
-  - Use camelCase when naming objects, functions, and instances
+  - Use camelCase when naming objects, functions, and instances. Abbreviations and acronyms should also use camel case when used as a name.
 
     ```javascript
     // bad
@@ -1020,12 +1020,20 @@
       name: 'Bob Parr'
     });
 
+    // bad
+    function parseJSON() {};
+    var XMLDocument;
+
     // good
     var thisIsMyObject = {};
     function thisIsMyFunction() {};
     var user = new User({
       name: 'Bob Parr'
     });
+
+    // good
+    function parseJson() {};
+    var xmlDocument;
     ```
 
   - Use PascalCase when naming constructors or classes
@@ -1048,6 +1056,16 @@
     var good = new User({
       name: 'yup'
     });
+    ```
+
+  - Use Screaming Snake Case for constants
+
+    ```javascript
+    // bad
+    var some_constant = 5;
+
+    // good
+    var SOME_CONSTANT = 5;
     ```
 
   - Use a leading underscore `_` when naming private properties
@@ -1089,7 +1107,7 @@
     }
     ```
 
-  - Name your functions. This is helpful for stack traces.
+  - Name your functions. This is helpful for stack traces. Note this is not necessary for class methods.
 
     ```javascript
     // bad
@@ -1100,6 +1118,20 @@
     // good
     var log = function log(msg) {
       console.log(msg);
+    };
+
+    // bad
+    var MyObj = {
+      log: function log(msg) {
+        console.log(msg);
+      }
+    };
+
+    // good
+    var MyObj = {
+      log: function(msg) {
+        console.log(msg);
+      }
     };
     ```
 


### PR DESCRIPTION
In the process of forking your amazing style guide and porting across some of the differences in our old internal style guide, we found some additional notes on naming conventions we thought might be worth sharing.

Includes recommendations on naming abbreviations, acronyms, constants and class methods.
