### PR TITLE
Clarify single newlines at the end of files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@
     var x = y + 5;
     ```
 
-  - Place an empty newline at the end of the file.
+  - End files with a single newline character.
 
     ```javascript
     // bad
@@ -787,11 +787,18 @@
     ```
 
     ```javascript
+    // bad
+    (function(global) {
+      // ...stuff...
+    })(this);↵
+    ↵
+    ```
+
+    ```javascript
     // good
     (function(global) {
       // ...stuff...
-    })(this);
-
+    })(this);↵
     ```
 
   - Use indentation when making long method chains.


### PR DESCRIPTION
In the process of adopting a variant of this guide at reddit, we encountered some ambiguity in the wording / examples of EOF style. It is possible to interpret the current wording as "add an extra blank newline at the end of each file", leading to double newlines. Unicode to the rescue!

cc @ajacksified

![<3](http://37.media.tumblr.com/53d25e7cc90723c9c75bf67a53bf3c6f/tumblr_ml0llcpFFs1qfy2kdo1_r1_500.gif)
