### PR TITLE
Add syntax highlighting to noConflict reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,7 +1287,7 @@
 
   - The module should start with a `!`. This ensures that if a malformed module forgets to include a final semicolon there aren't errors in production when the scripts get concatenated. [Explanation](https://github.com/airbnb/javascript/issues/44#issuecomment-13063933)
   - The file should be named with camelCase, live in a folder with the same name, and match the name of the single export.
-  - Add a method called noConflict() that sets the exported module to the previous version and returns this one.
+  - Add a method called `noConflict()` that sets the exported module to the previous version and returns this one.
   - Always declare `'use strict';` at the top of the module.
 
     ```javascript


### PR DESCRIPTION
Super small change, but it now fits in the with documents consistency.
