### PR TITLE
jshintrc cleanup

### DIFF
--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -25,14 +25,14 @@
   // Prohibit use of == and != in favor of === and !==.
   "eqeqeq": true,
 
-  // Suppress warnings about == null comparisons.
-  "eqnull": true,
-
   // Enforce tab width of 2 spaces.
   "indent": 2,
 
   // Prohibit use of a variable before it is defined.
   "latedef": true,
+
+  // Enforce line length to 80 characters
+  "maxlen": 80,
 
   // Require capitalized names for constructor functions.
   "newcap": true,
@@ -40,8 +40,8 @@
   // Enforce use of single quotation marks for strings.
   "quotmark": "single",
 
-  // Prohibit trailing whitespace.
-  "trailing": true,
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true,
 
   // Prohibit use of explicitly undeclared variables.
   "undef": true,
@@ -49,9 +49,11 @@
   // Warn when variables are defined but never used.
   "unused": true,
 
-  // Enforce line length to 80 characters
-  "maxlen": 80,
+  /*
+   * RELAXING OPTIONS
+   * =================
+   */
 
-  // Enforce placing 'use strict' at the top function scope
-  "strict": true
+  // Suppress warnings about == null comparisons.
+  "eqnull": true
 }


### PR DESCRIPTION
- eqnull is a relaxing option, not an enforcing option (http://www.jshint.com/docs/options/)
- trailing has been removed as of jshint 2.5 (https://github.com/jshint/jshint/releases/tag/2.5.0)
- put in alphabetical order
