### PR TITLE
Switch to one-variable-per-var from many-variables-per-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@
     ```
 
   - Use one `var` declaration per variable.
+    It's easier to add new variable declarations this way, and you never have
+    to worry about swapping out a `;` for a `,` or introducing punctuation-only
+    diffs. 
 
     ```javascript
     // bad
@@ -374,21 +377,16 @@
         goSportsTeam = true,
         dragonball = 'z';
 
+    // bad
+    // (compare to above, and try to spot the mistake)
+    var items = getItems(),
+        goSportsTeam = true;
+        dragonball = 'z';
+
     // good
     var items = getItems();
     var goSportsTeam = true;
     var dragonball = 'z';
-    ```
-
-    It's easier to add new variable declarations this way, and you never have
-    to worry about swapping out a `;` for a `,` or introducing punctuation-only
-    diffs. Also, you can't make the following mistake:
-
-    ```javascript
-    // can you catch the error?
-    var items = getItems(),
-        goSportsTeam = true;
-        dragonball = 'z';
     ```
 
   - Declare unassigned variables last. This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.


### PR DESCRIPTION
Frontenders at Airbnb at have been discussing this change for a bit, and
we've come to favor one-var-per-variable over one-var-only declarations.
Two things improve the maintainability of this style over one var for
multiple variables:
1. You never have a diff of a line that's removing a `;` and inserting
   a `,`.
2. You can't accidentally declare global variables because you have a
   one-character mistake (semicolon instead of comma):
   
   ``` javascript
   var foo = 1,
       bar = 2;
       baz = 3; // added later and (accidentally) declared globally
   ```

Also, make a docstring comment example JSDoc/GoogleClosureCompiler compatible
