### PR TITLE
put the dot with fn name when chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,11 +814,20 @@
     })(this);↵
     ```
 
-  - Use indentation when making long method chains.
+  - Use indentation when making long method chains. Use a leading dot, which
+    emphasizes that the line is a method call, not a new statement.
 
     ```javascript
     // bad
     $('#items').find('.selected').highlight().end().find('.open').updateCount();
+
+    // bad
+    $('#items').
+      find('selected').
+        highlight().
+        end().
+      find('.open').
+        updateCount();
 
     // good
     $('#items')


### PR DESCRIPTION
Reasons:
- styleguide already uses leading-dot style.
- leading dot emphasizes that the line is a method call, not a new statement. Consider the readability without whitespace:
```javascript
foo.
something().
else(); // <-- github JS parser error!

foo
.something()
.else();
```
- to spite @horaceko :snowman: 
- no one in semicolon-terminated languages would ever use the trailing-dot style.