### PR TITLE
Added consistent periods before code snippets, fixing Issue #231

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Types
 
-  - **Primitives**: When you access a primitive type you work directly on its value
+  - **Primitives**: When you access a primitive type you work directly on its value.
 
     + `string`
     + `number`
@@ -57,7 +57,7 @@
 
     console.log(foo, bar); // => 1, 9
     ```
-  - **Complex**: When you access a complex type you work on a reference to its value
+  - **Complex**: When you access a complex type you work on a reference to its value.
 
     + `object`
     + `array`
@@ -86,7 +86,7 @@
     var item = {};
     ```
 
-  - Don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61)
+  - Don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61).
 
     ```javascript
     // bad
@@ -125,7 +125,7 @@
 
 ## Arrays
 
-  - Use the literal syntax for array creation
+  - Use the literal syntax for array creation.
 
     ```javascript
     // bad
@@ -178,7 +178,7 @@
 
 ## Strings
 
-  - Use single quotes `''` for strings
+  - Use single quotes `''` for strings.
 
     ```javascript
     // bad
@@ -195,7 +195,7 @@
     ```
 
   - Strings longer than 80 characters should be written across multiple lines using string concatenation.
-  - Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40)
+  - Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40).
 
     ```javascript
     // bad
@@ -557,7 +557,7 @@
     }
     ```
 
-  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting) by [Ben Cherry](http://www.adequatelygood.com/)
+  - For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting) by [Ben Cherry](http://www.adequatelygood.com/).
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -606,7 +606,7 @@
     }
     ```
 
-  - For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll
+  - For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll.
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -706,7 +706,7 @@
 
   - Prefixing your comments with `FIXME` or `TODO` helps other developers quickly understand if you're pointing out a problem that needs to be revisited, or if you're suggesting a solution to the problem that needs to be implemented. These are different than regular comments because they are actionable. The actions are `FIXME -- need to figure this out` or `TODO -- need to implement`.
 
-  - Use `// FIXME:` to annotate problems
+  - Use `// FIXME:` to annotate problems.
 
     ```javascript
     function Calculator() {
@@ -718,7 +718,7 @@
     }
     ```
 
-  - Use `// TODO:` to annotate solutions to problems
+  - Use `// TODO:` to annotate solutions to problems.
 
     ```javascript
     function Calculator() {
@@ -735,7 +735,7 @@
 
 ## Whitespace
 
-  - Use soft tabs set to 2 spaces
+  - Use soft tabs set to 2 spaces.
 
     ```javascript
     // bad
@@ -1042,7 +1042,7 @@
     }
     ```
 
-  - Use camelCase when naming objects, functions, and instances
+  - Use camelCase when naming objects, functions, and instances.
 
     ```javascript
     // bad
@@ -1061,7 +1061,7 @@
     });
     ```
 
-  - Use PascalCase when naming constructors or classes
+  - Use PascalCase when naming constructors or classes.
 
     ```javascript
     // bad
@@ -1083,7 +1083,7 @@
     });
     ```
 
-  - Use a leading underscore `_` when naming private properties
+  - Use a leading underscore `_` when naming private properties.
 
     ```javascript
     // bad
@@ -1143,8 +1143,8 @@
 
 ## Accessors
 
-  - Accessor functions for properties are not required
-  - If you do make accessor functions use getVal() and setVal('hello')
+  - Accessor functions for properties are not required.
+  - If you do make accessor functions use getVal() and setVal('hello').
 
     ```javascript
     // bad
@@ -1160,7 +1160,7 @@
     dragon.setAge(25);
     ```
 
-  - If the property is a boolean, use isVal() or hasVal()
+  - If the property is a boolean, use isVal() or hasVal().
 
     ```javascript
     // bad
@@ -1406,7 +1406,7 @@
 
 ## ECMAScript 5 Compatibility
 
-  - Refer to [Kangax](https://twitter.com/kangax/)'s ES5 [compatibility table](http://kangax.github.com/es5-compat-table/)
+  - Refer to [Kangax](https://twitter.com/kangax/)'s ES5 [compatibility table](http://kangax.github.com/es5-compat-table/).
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
As outlined in Issue #231, the sentence leading into code blocks has inconsistent punctuation. Sometimes it has a period, sometimes it has no punctuation, and occasionally it has colons. I left the colon lines untouched, but added in periods to the sentences that had no punctuation. 

Let me know if you have any other preferences and I'm happy to modify the PR! This should just make it easier to read for people like myself who waste small amounts of mental energy worrying about the missing punctuation. 

Example sentence with no punctuation: 
![image](https://cloud.githubusercontent.com/assets/7017045/5931072/4e09c20c-a64d-11e4-8dee-edfab7b5c25b.png)

Example fix with a period: 
![image](https://cloud.githubusercontent.com/assets/7017045/5931080/5caafd26-a64d-11e4-83c3-5e5adc84cd79.png)

 