### PR TITLE
(Fix) Add semicolon to whitespace code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@
       return bar;
     }
 
-    return baz
+    return baz;
 
     // bad
     var obj = {


### PR DESCRIPTION
# About
A semicolon appears to be unintentionally left out of a syntax code example related to 'Whitespace: Leave a blank line after blocks and before the next statement'. 

## In this commit
Add semicolon at the end of line 871's statement.
