### PR TITLE
Fixes #251 - Rename Conditional Expressions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   1. [Properties](#properties)
   1. [Variables](#variables)
   1. [Hoisting](#hoisting)
-  1. [Conditional Expressions & Equality](#conditional-expressions--equality)
+  1. [Comparison Operators & Equality](#comparison-operators--equality)
   1. [Blocks](#blocks)
   1. [Comments](#comments)
   1. [Whitespace](#whitespace)
@@ -563,10 +563,10 @@
 
 
 
-## Conditional Expressions & Equality
+## Comparison Operators & Equality
 
   - Use `===` and `!==` over `==` and `!=`.
-  - Conditional expressions are evaluated using coercion with the `ToBoolean` method and always follow these simple rules:
+  - Comparison operators are evaluated using coercion with the `ToBoolean` method and always follow these simple rules:
 
     + **Objects** evaluate to **true**
     + **Undefined** evaluates to **false**


### PR DESCRIPTION
As per issue #251, renames section Conditional Expressions & Equality to Comparison Operators & Equality, as the section is not about the Elvis operator :)