### PR TITLE
Added naming conventions for UPPERCASE use cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3140,31 +3140,42 @@ Other Style Guides
     ```
 
   <a name="naming--uppercase"></a>
-  - [23.10](#naming--uppercase) Use UPPERCASE for nested object namespacing, global variables, and constants.
+  - [23.10](#naming--uppercase) You may optionally uppercase a constant only if it (1) is exported, (2) is a `const` (it can not be reassigned), and (3) the programmer can trust it (and its nested properties) to never change.
 
+    > Why? This is an additional tool to assist in situations where the programmer would be unsure if a variable might ever change. UPPERCASE_VARIABLES are letting the programmer know that they can trust the variable (and its properties) not to change.
+    - What about all `const` variables? - This is unnecessary, so uppercasing should not be used for constants within a file. It should be used for exported constants however.
+    - What about exported objects? - Uppercase at the top level of export  (e.g. `EXPORTED_OBJECT.key`) and maintain that all nested properties do not change.
 
     ```javascript
     // bad
-    const namespace = namespace || {};
-
-    namespace.util.Widget = {
-       // ...stuff...
-    }
+    const PRIVATE_VARIABLE = 'should not be unnecessarily uppercased within a file';
 
     // bad
-    const apiKey = '44b345234534t455245njkl523452-vbb9';
+    export const THING_TO_BE_CHANGED = 'should obviously not be uppercased';
+
+    // bad
+    export let REASSIGNABLE_VARIABLE = 'do not use let with uppercase variables';
+
+    // ---
+
+    // allowed but does not supply semantic value
+    export const apiKey = 'SOMEKEY';
+
+    // better in most cases
+    export const API_KEY = 'SOMEKEY';
+
+    // ---
+
+    // bad - unnecessarily uppercases key while adding no semantic value
+    export const MAPPING = {
+      KEY: 'value'
+    };
 
     // good
-    const NAMESPACE = NAMESPACE || {};
-
-    NAMESPACE.util.Widget = {
-       // ...stuff...
-    }
-
-    // good
-    const API_KEY = '44b345234534t455245njkl523452-vbb9';
+    export const MAPPING = {
+      key: 'value'
+    };
     ```
-
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -3139,6 +3139,33 @@ Other Style Guides
     ];
     ```
 
+  <a name="naming--uppercase"></a>
+  - [23.10](#naming--uppercase) Use UPPERCASE for nested object namespacing, global variables, and constants.
+
+
+    ```javascript
+    // bad
+    const namespace = namespace || {};
+
+    namespace.util.Widget = {
+       // ...stuff...
+    }
+
+    // bad
+    const apiKey = '44b345234534t455245njkl523452-vbb9';
+
+    // good
+    const NAMESPACE = NAMESPACE || {};
+
+    NAMESPACE.util.Widget = {
+       // ...stuff...
+    }
+
+    // good
+    const API_KEY = '44b345234534t455245njkl523452-vbb9';
+    ```
+
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Accessors


### PR DESCRIPTION
Constants, globals and nested object namespacing, by convention, use all UPPERCASE for those variable names.

also removed an extra line space from line 142.
