### PR TITLE
Fix examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,25 +446,25 @@
 
       return name;
     }
-
+    
     // bad
     function() {
-      var name = getName();
-
       if (!arguments.length) {
         return false;
       }
+
+      var name = getName();
 
       return true;
     }
 
     // good
     function() {
+      var name = getName();
+
       if (!arguments.length) {
         return false;
       }
-
-      var name = getName();
 
       return true;
     }


### PR DESCRIPTION
The 'bad' and 'good' labels were wrongly placed for the variable declaration examples. An `if` statement before the variable declaration was labeled as 'good' while the following example with a variable declaration before the `if` statement was labeled as 'bad'.