### PR TITLE
Resolves issue #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,9 @@
 
       return name;
     }
-
+    
+ - Declare variables at the top of their scope even if they are unassigned to avoid variable declaration hoisting. 
+ 
     // bad
     function() {
       var name = getName();
@@ -460,11 +462,12 @@
 
     // good
     function() {
+      var name;
       if (!arguments.length) {
         return false;
       }
 
-      var name = getName();
+      name = getName();
 
       return true;
     }

--- a/README.md
+++ b/README.md
@@ -447,8 +447,8 @@
       return name;
     }
     ```
-    
- - Declare variables at the top of their scope even if they are unassigned to avoid variable declaration hoisting. 
+
+  - Declare variables at the top of their scope even if they are unassigned to avoid variable declaration hoisting. 
  
  ```javascript
     // bad

--- a/README.md
+++ b/README.md
@@ -446,9 +446,11 @@
 
       return name;
     }
+    ```
     
  - Declare variables at the top of their scope even if they are unassigned to avoid variable declaration hoisting. 
  
+ ```javascript
     // bad
     function() {
       var name = getName();


### PR DESCRIPTION
Unclear code example in variables section. Variables should be declared at the top of their scope to avoid declaration hoisting.