### PR TITLE
Add ESLint support

### DIFF
--- a/linters/eslintrc
+++ b/linters/eslintrc
@@ -1,8 +1,6 @@
 env: 
   browser: true
   node: true
-  amd: true
-  jquery: true
 
 rules:
   no-new-object: 2

--- a/linters/eslintrc
+++ b/linters/eslintrc
@@ -33,6 +33,7 @@ rules:
   space-before-function-paren: [2, "never"]
   no-spaced-func: 2
   no-wrap-func: 2
+  one-var: [2, "never"]
   camelcase: 2
   new-cap: 2
   consistent-this: [1, "_this"]

--- a/linters/eslintrc
+++ b/linters/eslintrc
@@ -1,0 +1,44 @@
+env: 
+  browser: true
+  node: true
+  amd: true
+  jquery: true
+
+rules:
+  no-new-object: 2
+  no-reserved-keys: 2
+  no-array-constructor: 2
+  quotes: [2, "single"]
+  indent: [2, 2]
+  no-multi-str: 2
+  no-multi-spaces: 2
+  no-shadow-restricted-names: 2
+  dot-notation: 2
+  block-scoped-var: 2
+  vars-on-top: 2
+  no-unused-vars: 2
+  eqeqeq: 2
+  use-isnan: 2
+  no-eq-null: 2
+  brace-style: 2
+  spaced-line-comment: 2
+  valid-jsdoc: 2
+  space-infix-ops: 2
+  eol-last: 2
+  padded-blocks: [2, "never"]
+  space-before-blocks: 2
+  comma-dangle: [2, "never"]
+  comma-style: 2
+  semi: [2, always]
+  semi-spacing: 2
+  no-extra-boolean-cast: 2
+  space-before-function-paren: [2, "never"]
+  no-spaced-func: 2
+  no-wrap-func: 2
+  camelcase: 2
+  new-cap: 2
+  consistent-this: [1, "_this"]
+  func-names: 2
+  key-spacing: 2
+  no-dupe-keys: 2
+  strict: 2


### PR DESCRIPTION
[ESLint](http://eslint.org/) is an alternative to JSHint. This is just a rough start, feel free to add more.

References: https://github.com/airbnb/javascript/issues/259