### PR TITLE
Fix minor punctuation errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@
     }
     ```
 
-  - Never name a parameter `arguments`, this will take precedence over the `arguments` object that is given to every function scope.
+  - Never name a parameter `arguments`. This will take precedence over the `arguments` object that is given to every function scope.
 
     ```javascript
     // bad
@@ -475,7 +475,7 @@
 
 ## Hoisting
 
-  - Variable declarations get hoisted to the top of their scope, their assignment does not.
+  - Variable declarations get hoisted to the top of their scope, but their assignment does not.
 
     ```javascript
     // we know this wouldn't work (assuming there
@@ -665,7 +665,7 @@
 
 ## Comments
 
-  - Use `/** ... */` for multiline comments. Include a description, specify types and values for all parameters and return values.
+  - Use `/** ... */` for multi-line comments. Include a description, specify types and values for all parameters and return values.
 
     ```javascript
     // bad


### PR DESCRIPTION
(1) BEFORE: Never name a parameter `arguments`, this will take precedence over the `arguments` object.
AFTER: Never name a parameter `arguments`. This will take precedence over the `arguments` object.

(2) BEFORE: Variable declarations get hoisted to the top of their scope, their assignment does not.
AFTER:
Variable declarations get hoisted to the top of their scope, but their assignment does not.

(3) BEFORE: for multiline comments
AFTER: for multi-line comments