### PR TITLE
Fix inconsistent use of direct assignment in place of Array#push

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@
       items = [];
 
       for (i = 0; i < length; i++) {
-        items[i] = '<li>' + messages[i].message + '</li>';
+        items.push('<li>' + messages[i].message + '</li>');
       }
 
       return '<ul>' + items.join('') + '</ul>';


### PR DESCRIPTION
Style guide on Arrays specifies that one should avoid using direct assignment. Section on using Array#join in place of string concatenation now follows this recommendation.