### PR TITLE
Add `esnext` to the jsHint configuration

### DIFF
--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -13,6 +13,9 @@
   // Define globals exposed by Node.js.
   "node": true,
 
+  // Allow ES6.
+  "esnext": true,
+
   /*
    * ENFORCING OPTIONS
    * =================


### PR DESCRIPTION
This way we'll allow ES6 syntax.