### PR TITLE
Fix "Group all your `conts`s and then group all your `let`s." example

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,9 +880,9 @@
 
     // bad
     let i;
-    let items = getItems();
+    const items = getItems();
     let dragonball;
-    let goSportsTeam = true;
+    const goSportsTeam = true;
     let len;
 
     // good


### PR DESCRIPTION
This PR fixes the example "Group all your `conts`s and then group all your `let`s." in the "Variables" section.



