### PR TITLE
Fix hoisting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,7 +985,7 @@
 
       anonymous(); // => TypeError anonymous is not a function
 
-      let anonymous = function() {
+      var anonymous = function() {
         console.log('anonymous function expression');
       };
     }
@@ -1001,7 +1001,7 @@
 
       superPower(); // => ReferenceError superPower is not defined
 
-      let named = function superPower() {
+      var named = function superPower() {
         console.log('Flying');
       };
     }
@@ -1013,7 +1013,7 @@
 
       named(); // => TypeError named is not a function
 
-      let named = function named() {
+      var named = function named() {
         console.log('named');
       }
     }


### PR DESCRIPTION
Hoisting only happens to `var`. As kangax describes in [Why `typeof` is no longer “safe”](http://es-discourse.com/t/why-typeof-is-no-longer-safe/15/3).

Also, I wonder if we need the whole section, since you recommend to [avoid using `var` altogether](https://github.com/airbnb/javascript/blob/b492/README.md#references).

BTW, this is a clean version of #303.