### PR TITLE
Add note on concatenating a string to an existing value

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,20 @@
     }
     ```
 
+- When simply adding a string to an existing value, use concatenation.
+
+    ```javascript
+    // bad
+    function makePercent(num) {
+      return `${num}%`;
+    }
+
+    // good
+    function makePercent(num) {
+      return num + '%';
+    }
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 


### PR DESCRIPTION
We're in the process of converting Video.js to ES6, and one of our devs assumed that this meant all string concatenation should be replaced with string templates. In some cases though this makes the code less readable. It's more obvious when you're using more complicated variables.

```
const rateName = `${this.player.getPlaybackRate()}x`
// vs
const rateName = this.player.getPlaybackRate() + 'x'
```

The general rule we landed on was:
- When variables are being added to a string, use a string template
- When a string is being added to a variable, use concatenation

There could be a better way to say that. For the original example, see https://github.com/videojs/video.js/pull/2015#discussion_r27932379