### PR TITLE
Clarifying what rule is being enforced.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,17 +1147,12 @@
     // bad
     var OBJEcttsssss = {};
     var this_is_my_object = {};
+    var o = {};
     function c() {}
-    var u = new user({
-      name: 'Bob Parr'
-    });
 
     // good
     var thisIsMyObject = {};
     function thisIsMyFunction() {}
-    var user = new User({
-      name: 'Bob Parr'
-    });
     ```
 
   - Use PascalCase when naming constructors or classes.


### PR DESCRIPTION
Capitalization of constructors is not the rule in question here.  It makes it more clear what the offending difference is between `//bad` and `//good` to have consistent constructor capitalization.