### PR TITLE
Allow reserved words as keys in ES6 module context

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@
     const item = {};
     ```
 
-  - [3.2](#3.2) <a name='3.2'></a> Don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61).
+  - [3.2](#3.2) <a name='3.2'></a> If your code will be executed in browsers in script context, don't use [reserved words](http://es5.github.io/#x7.6.1) as keys. It won't work in IE8. [More info](https://github.com/airbnb/javascript/issues/61). It’s OK to use them in ES6 modules and server-side code.
 
     ```javascript
     // bad


### PR DESCRIPTION
`<script type="module">` and *node* code imply full support of ES5.

Code transpiled by *babel* is also perfecly safe:

```js
$ cat <<––– | babel
const superman = {
  default: { clark: 'kent' },
  private: true
};
–––
"use strict";

var superman = {
   "default": { clark: "kent" },
   "private": true
};
```