### PR TITLE
Fixed spacing on code block under Comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,7 @@
         this.total = 0;
       }
     }
-  ```
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/es5/README.md
+++ b/es5/README.md
@@ -757,7 +757,7 @@
 
       return this;
     }
-  ```
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Even though github was rendering this correctly; I did this to fix tools
like https://github.com/suan/vim-instant-markdown from breaking syntax.