### PR TITLE
add eslint rules for JSX style from issue #345

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -1,5 +1,8 @@
 {
   "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
   "env": {
     "browser": true,
     "node": true
@@ -164,6 +167,46 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-line-comment": 2         // http://eslint.org/docs/rules/spaced-line-comment
+    "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
+
+/**
+ * JSX style
+ */
+    "react/display-name": 0,
+    "react/jsx-boolean-value": 2,
+    "react/jsx-quotes": [2, "double"],
+    "react/jsx-no-undef": 2,
+    "react/jsx-sort-props": 0,
+    "react/jsx-sort-prop-types": 0,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/no-did-mount-set-state": [2, "allow-in-func"],
+    "react/no-did-update-set-state": 2,
+    "react/no-multi-comp": 2,
+    "react/no-unknown-property": 2,
+    "react/prop-types": 2,
+    "react/react-in-jsx-scope": 2,
+    "react/self-closing-comp": 2,
+    "react/wrap-multilines": 2,
+    "react/sort-comp": [2, {
+      "order": [
+        "displayName",
+        "mixins",
+        "statics",
+        "propTypes",
+        "getDefaultProps",
+        "getInitialState",
+        "componentWillMount",
+        "componentDidMount",
+        "componentWillReceiveProps",
+        "shouldComponentUpdate",
+        "componentWillUpdate",
+        "componentWillUnmount",
+        "/^on.+$/",
+        "/^get.+$/",
+        "/^render.+$/",
+        "render"
+      ]
+    }]
   }
 }

--- a/linters/README.md
+++ b/linters/README.md
@@ -1,0 +1,7 @@
+## `.eslintrc`
+
+Our `.eslintrc` requires the following NPM packages packages:
+
+- `eslint`
+- `babel-eslint`
+- `eslint-plugin-react`


### PR DESCRIPTION
Adds React style to our `.eslintrc.` These rules were authored by @nkt

Should we keep these rules separate from our base `.eslintrc` or is it fine to put them in here?