### PR TITLE
Create package eslint-config-airbnb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.0",
   "description": "A mostly reasonable approach to JavaScript.",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "publish-all": "npm publish && cd ./packages/eslint-config-airbnb && npm publish"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,0 +1,1 @@
+module.exports = require('airbnb-style/linters/.eslintrc');

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,1 +1,11 @@
-module.exports = require('airbnb-style/linters/.eslintrc');
+var resolve = require('resolve');
+var stripComments = require('strip-json-comments');
+var fs = require('fs');
+
+// you could do this all at once if you wanted to look cool
+var filename = resolve.sync('airbnb-style/linters/.eslintrc');
+var data = fs.readFileSync(filename, {encoding: 'utf-8'});
+var dataWithoutComments = stripComments(data);
+var parsed = JSON.parse(dataWithoutComments);
+
+module.exports = parsed;

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-airbnb",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "description": "Airbnb's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "eslint",
+    "eslintconfig",
     "config",
     "airbnb",
     "javascript",

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -27,6 +27,8 @@
     "airbnb-style": "2.0.0",
     "babel-eslint": "3.1.7",
     "eslint": "0.21.2",
-    "eslint-plugin-react": "2.3.0"
+    "eslint-plugin-react": "2.3.0",
+    "resolve": "1.1.6",
+    "strip-json-comments": "1.0.2"
   }
 }

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-airbnb",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Airbnb's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "eslint-config-airbnb",
+  "version": "0.0.1",
+  "description": "Airbnb's ESLint config, following our styleguide",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/airbnb/javascript"
+  },
+  "keywords": [
+    "eslint",
+    "config",
+    "airbnb",
+    "javascript",
+    "styleguide"
+  ],
+  "author": "Jake Teton-Landis (https://twitter.com/@jitl)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/airbnb/javascript/issues"
+  },
+  "homepage": "https://github.com/airbnb/javascript",
+  "dependencies": {
+    "airbnb-style": "2.0.0",
+    "babel-eslint": "3.1.7",
+    "eslint": "0.21.2",
+    "eslint-plugin-react": "2.3.0"
+  }
+}


### PR DESCRIPTION
This is a sharable ESLint config package. We could optionally just use our eslint config as the package `main` for `airbnb-style` but it'd be nicer for everyone if the eslint package had a cool name.

Solves for issue #349 