### PR TITLE
added trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@
     // bad
     const superman = {
       default: { clark: 'kent' },
-      private: true
+      private: true,
     };
 
     // good
     const superman = {
       defaults: { clark: 'kent' },
-      hidden: true
+      hidden: true,
     };
     ```
 
@@ -161,17 +161,17 @@
     ```javascript
     // bad
     const superman = {
-      class: 'alien'
+      class: 'alien',
     };
 
     // bad
     const superman = {
-      klass: 'alien'
+      klass: 'alien',
     };
 
     // good
     const superman = {
-      type: 'alien'
+      type: 'alien',
     };
     ```
 
@@ -234,12 +234,12 @@
 
     // bad
     const obj = {
-      lukeSkywalker: lukeSkywalker
+      lukeSkywalker: lukeSkywalker,
     };
 
     // good
     const obj = {
-      lukeSkywalker
+      lukeSkywalker,
     };
     ```
 
@@ -1272,13 +1272,13 @@
     // bad
     dog.set('attr',{
       age: '1 year',
-      breed: 'Bernese Mountain Dog'
+      breed: 'Bernese Mountain Dog',
     });
 
     // good
     dog.set('attr', {
       age: '1 year',
-      breed: 'Bernese Mountain Dog'
+      breed: 'Bernese Mountain Dog',
     });
     ```
 


### PR DESCRIPTION
In some parts of this style guide, trailing commas are not used for other examples outside the comma section.

According to the [comma section](https://github.com/arianf/javascript#19.2) of this style guide, trailing commas should be used. But outside of that section, it is commonly not used in this style guide.

I think for consistency, when the section/topic of the style guide is not focused on the trailing comma's, they should be used. Especially because it is confusing to see a good example that doesn't include the trailing comma.

