### PR TITLE
Update jsHint config

### DIFF
--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -15,6 +15,7 @@
 
   // Allow ES6.
   "esnext": true,
+  "proto": true,
 
   /*
    * ENFORCING OPTIONS


### PR DESCRIPTION
Although `__proto__` can be misused, it’s now [part of the ES 2015 spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-additional-properties-of-the-object.prototype-object). JsHint seems to lag behind a little – it still issues a warning even if `esnext` is on.

http://stackoverflow.com/a/29254531/2816199