### PR TITLE
Added "prefer-const" rule

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -37,6 +37,7 @@
  * ES6
  */
     "no-var": 2,                     // http://eslint.org/docs/rules/no-var
+    "prefer-const": 2,               // http://eslint.org/docs/rules/prefer-const
 
 /**
  * Variables


### PR DESCRIPTION
Added new ES6 rule, introduced in eslint 0.23.0
 > This rule is aimed to flag variables that are declared using let keyword, but never modified after initial assignment.