### PR TITLE
Update to include warning against using eval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@
       return `How are you, ${name}?`;
     }
     ```
+  - [6.5](#6.5) <a name='6.5'></a> Never use eval() on a string, it opens too many vulnerabilities.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Added 6.5 to strings section of Readme in order to explicitly warn against using eval(). Listed in ticket #118.

No other lines were edited or removed.

![screen shot 2015-07-03 at 7 52 45 pm](https://cloud.githubusercontent.com/assets/3507287/8506231/59cb07f2-21bf-11e5-88d4-c5f585f19fcf.png)
