### PR TITLE
Fixed typo in 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@
 
     ```javascript
     class Jedi {
-      contructor(options = {}) {
+      constructor(options = {}) {
         this.name = options.name || 'no name';
       }
 


### PR DESCRIPTION
Line read `contructor(options = {}) {` 

Edited to `constructor(options = {}) {`

No other lines were edited or changed.

![screen shot 2015-07-04 at 10 36 30 am](https://cloud.githubusercontent.com/assets/3507287/8508875/9dfc5510-2238-11e5-8b8d-87d0c0003c84.png)