### PR TITLE
Fixed typo in 13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@
       return name;
     }
 
-    // bad - unnessary function call
+    // bad - unnecessary function call
     function(hasName) {
       const name = getName();
 


### PR DESCRIPTION
A comment in the example of section 13.4 had 'unnecessary' spelled as 'unnessary'

No other lines were edited or removed.

![screen shot 2015-07-04 at 10 49 01 am](https://cloud.githubusercontent.com/assets/3507287/8508905/58a203f0-223a-11e5-8ce5-a1b85614dfab.png)
