### PR TITLE
Fixed typo in 19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,14 +1466,14 @@
          firstName: 'Florence',
     -    lastName: 'Nightingale'
     +    lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb graph', 'mordern nursing']
+    +    inventorOf: ['coxcomb graph', 'modern nursing']
     }
 
     // good - git diff with trailing comma
     const hero = {
          firstName: 'Florence',
          lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'mordern nursing'],
+    +    inventorOf: ['coxcomb chart', 'modern nursing'],
     }
 
     // bad


### PR DESCRIPTION
'modern' was spelled as 'mordern' in both the good and bad examples of section 19.2

No other lines were edited or removed.

![screen shot 2015-07-04 at 10 56 24 am](https://cloud.githubusercontent.com/assets/3507287/8508923/613c43b2-223b-11e5-9c06-b74700d842b0.png)
