### PR TITLE
Move babel-eslint to peer dependencies

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -24,9 +24,11 @@
     "url": "https://github.com/airbnb/javascript/issues"
   },
   "homepage": "https://github.com/airbnb/javascript",
+  "peerDependencies": {
+    "babel-eslint": "3.x"
+  },
   "dependencies": {
     "airbnb-style": "2.0.0",
-    "babel-eslint": "3.1.7",
     "eslint": "0.21.2",
     "eslint-plugin-react": "2.3.0",
     "resolve": "1.1.6",


### PR DESCRIPTION
The reason for this is that config is something that is mixed in into a main config. And main project not necessarily has babel-eslint in there. Internal dependency of eslint-config-airbnb is ignored (it is not a module, rules/keys are just mixed in by eslint), so when you run lint there is an error that "babel-eslint is not found".