### PR TITLE
Fixed contradiction in the Comments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,7 @@
     ```javascript
     class Calculator {
       constructor() {
+      
         // FIXME: shouldn't use a global here
         total = 0;
       }
@@ -1226,6 +1227,7 @@
     ```javascript
     class Calculator {
       constructor() {
+      
         // TODO: total should be configurable by an options param
         this.total = 0;
       }


### PR DESCRIPTION
Section 17.2 in the style guide says to leave an empty line above a single-line comment, but I found two instances where that was not followed. Ironically, both instances happen in the same section (Section 17).

https://github.com/airbnb/javascript#17.2

"Use `//` for single line comments. Place single line comments on a newline above the subject of the comment. **Put an empty line before the comment.**"
