### PR TITLE
Proper ESLint React components order validation

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -208,7 +208,7 @@
         "componentDidUpdate",
         "componentWillUnmount",
         "/^on.+$/",
-        "/^get.+$/",
+        "/^get(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
         "/^render.+$/",
         "render"
       ]


### PR DESCRIPTION
It fixes validation of React methods order.

For example, when I had:

```js
const Input = React.createClass({
  componentDidMount() {
    console.log('mounted');
  },

  getInitialState() {
    return {
      a: 1,
    };
  },
});
```

Linter showed no errors. That happened because of `/^get.+$/` regexp. It matched with getInitalState so it was allowed to place `getInitialState` below `componentDidMount`. 