### PR TITLE
add constructor as an alias for componentWillMount

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -197,6 +197,7 @@
         "mixins",
         "statics",
         "defaultProps",
+        "constructor",
         "getDefaultProps",
         "getInitialState",
         "getChildContext",


### PR DESCRIPTION
As far as we can use ES6+ syntax, we should add it to the styleguide.
See details here http://babeljs.io/blog/2015/06/07/react-on-es6-plus/

what do you think?