### PR TITLE
Add Waysact exception for single quote -> double quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+# Waysact Exceptions
+
+  1. All strings are double quoted.
+
 # Airbnb JavaScript Style Guide() {
 
 *A mostly reasonable approach to JavaScript*

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -127,7 +127,7 @@
       "allowSingleLine": true
     }],
     "quotes": [
-      2, "single", "avoid-escape"    // http://eslint.org/docs/rules/quotes
+      2, "double"                    // http://eslint.org/docs/rules/quotes
     ],
     "camelcase": [2, {               // http://eslint.org/docs/rules/camelcase
       "properties": "never"

--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -40,8 +40,8 @@
   // Require capitalized names for constructor functions.
   "newcap": true,
 
-  // Enforce use of single quotation marks for strings.
-  "quotmark": "single",
+  // Enforce use of double quotation marks for strings.
+  "quotmark": "double",
 
   // Enforce placing 'use strict' at the top function scope
   "strict": true,


### PR DESCRIPTION
Based on discussion in new-backend-dev, we prefer sticking to one style of quoting strings... rather than single quotes in JS and double quotes in JSX as suggested by this style guide.