### PR TITLE
Update Standard ECMA-262 and Add You Don't Know JS: ES6 book

### DIFF
--- a/README.md
+++ b/README.md
@@ -1984,7 +1984,7 @@
 
 **Read This**
 
-  - [Annotated ECMAScript 5.1](http://es5.github.com/)
+  - [Standard ECMA-262](http://www.ecma-international.org/ecma-262/6.0/index.html)
 
 **Tools**
 

--- a/README.md
+++ b/README.md
@@ -2031,6 +2031,7 @@
   - [Third Party JavaScript](http://manning.com/vinegar/) - Ben Vinegar and Anton Kovalyov
   - [Effective JavaScript: 68 Specific Ways to Harness the Power of JavaScript](http://amzn.com/0321812182) - David Herman
   - [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
+  - [You Don't Know JS: ES6 & Beyond](http://shop.oreilly.com/product/0636920033769.do) - Kyle Simpson
 
 **Blogs**
 


### PR DESCRIPTION
- In the Resources section, the Annotated ECMAScript 5.1 was replaced by
  Standard ECMA-262, which is a ECMAScript® 2015 Language Specification
- Add You Don't Know JS: ES6 & Beyond book by Kyle Simpson