### PR TITLE
Always use braces in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,15 +1094,12 @@ Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
 
 ## Blocks
 
-  - [16.1](#16.1) <a name='16.1'></a> Use braces with all multi-line blocks.
+  - [16.1](#16.1) <a name='16.1'></a> Use braces with all single- and multi-line blocks.
 
     ```javascript
     // bad
     if (test)
       return false;
-
-    // good
-    if (test) return false;
 
     // good
     if (test) {
@@ -1140,6 +1137,20 @@ Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
     }
     ```
 
+  - [16.3](#16.3) <a name='16.3'></a> Never place block code on the same line as the block braces.
+
+    ```javascript
+    // bad
+    if (test) return false;
+
+    // bad
+    if (test) { return false; }
+
+    // good
+    if (test) {
+      return false;
+    }
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
-# Airbnb JavaScript Style Guide() {
+# Hudl JavaScript Style Guide() {
 
 *A mostly reasonable approach to JavaScript*
+
+Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
 
 [For the ES5-only guide click here](es5/).
 


### PR DESCRIPTION
Talked to some of the other devs about this in #lang-javascript; the general consensus was that people preferred using braces because it was clearer and helped other devs avoid forgetting to add braces if they added lines to the code block.  Sparked by the following question:

> Basic style guide question... preferable to do

> ```if (error) return error;```

> or

> ```
if (error) {
  return error;
}
```

> ? 