### PR TITLE
Get rid of `no-reserved-keys` in the .eslintrc

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -69,7 +69,6 @@
     "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
     "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
     "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
-    "no-reserved-keys": 2,           // http://eslint.org/docs/rules/no-reserved-keys
     "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
     "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
     "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan


### PR DESCRIPTION
After all, [rule 8.2](https://github.com/airbnb/javascript/tree/63bece1#3.2) allows them in an ES 2015+ environment.