### PR TITLE
Replace deprecated ESLint rules

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -166,7 +166,7 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
+    "spaced-comment": 2,             // http://eslint.org/docs/rules/spaced-comment
 
 /**
  * JSX style

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -152,7 +152,7 @@
     "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
     "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
     "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
-    "no-wrap-func": 2,               // http://eslint.org/docs/rules/no-wrap-func
+    "no-extra-parens": 2,            // http://eslint.org/docs/rules/no-extra-parens
     "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
     "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
     "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks


### PR DESCRIPTION
http://eslint.org/docs/rules/no-wrap-func
http://eslint.org/docs/rules/spaced-comment

Both have been deprecated and will be removed from ESLint soon.