### PR TITLE
Support `restParams` in ESLint

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -20,6 +20,7 @@
     "objectLiteralDuplicateProperties": false,
     "objectLiteralShorthandMethods": true,
     "objectLiteralShorthandProperties": true,
+    "restParams": true,
     "spread": true,
     "superInFunctions": true,
     "templateStrings": true,


### PR DESCRIPTION
Otherwise we get this error ( https://github.com/eslint/eslint/issues/2346 ) when using the default parser on code like `(...args) => result`. Code which [couldn’t be more valid](https://github.com/airbnb/javascript/tree/0c29596a7eaf8f03c8a85428014075041098db0f#7.6).