### PR TITLE
[eslint] allow +, -, =, ! in comments without a space

### DIFF
--- a/packages/eslint-config-airbnb/.eslintrc
+++ b/packages/eslint-config-airbnb/.eslintrc
@@ -166,7 +166,10 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-comment": 2,             // http://eslint.org/docs/rules/spaced-comment
+    "spaced-comment": [2, "always",  {// http://eslint.org/docs/rules/spaced-comment
+      "exceptions": ["-", "+"],
+      "markers": ["=", "!"]           // space here to support sprockets directives
+    }],
 
 /**
  * JSX style


### PR DESCRIPTION
Allow a few exceptions to the `spaced-comment` rule.

- `=` is required for sprockets files.
- `-` and `+` are commonly used to draw long lines across the screen.
- `!` is used for some of our comment directives.