### PR TITLE
Mention eslint-config-airbnb

### DIFF
--- a/linters/README.md
+++ b/linters/README.md
@@ -2,6 +2,7 @@
 
 Our `.eslintrc` requires the following NPM packages:
 
+- `eslint-config-airbnb`
 - `eslint`
 - `babel-eslint`
 - `eslint-plugin-react`


### PR DESCRIPTION
Actually, if we want to make the thing more convenient, we could go as far as saying:

    Before using our `.eslintrc` install these dependencies:

    ```sh
    npm install --save-dev eslint-config-airbnb eslint babel-eslint eslint-plugin-react
    ```

I want to leave the decision up to you though.