### PR TITLE
Add missing `state`

### DIFF
--- a/packages/eslint-config-airbnb/.eslintrc
+++ b/packages/eslint-config-airbnb/.eslintrc
@@ -199,6 +199,7 @@
         "mixins",
         "statics",
         "defaultProps",
+        "state",
         "constructor",
         "getDefaultProps",
         "getInitialState",


### PR DESCRIPTION
There's `defaultProps` but there's no `state` for React.