### PR TITLE
Put `everything-else` before `render`

### DIFF
--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -211,6 +211,7 @@ module.exports = {
         'componentDidUpdate',
         'componentWillUnmount',
         '/^on.+$/',
+        'everything-else',
         '/^get.+$/',
         '/^render.+$/',
         'render'


### PR DESCRIPTION
When there is a custom method which is neither a handler nor a getter, put it between the two groups so that it doesn't end up after the `render` method.

This behavior is closer to the [default](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md#rule-options).