### PR TITLE
Add state to sort-comp rule before render

### DIFF
--- a/packages/eslint-config-airbnb/.eslintrc
+++ b/packages/eslint-config-airbnb/.eslintrc
@@ -202,6 +202,7 @@
         "constructor",
         "getDefaultProps",
         "getInitialState",
+        "state",
         "getChildContext",
         "componentWillMount",
         "componentDidMount",


### PR DESCRIPTION
When using class properties you can just write

```javascript
class App extends Component {
  state = {counter: 0}

  render() { /* ... */ }
}
```

`state` should come before `render`