### PR TITLE
Updated 25.1 to include a case with a lookup that has a hyphen in the classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -1874,6 +1874,9 @@
 
     // good
     const $sidebar = $('.sidebar');
+
+    // good
+    const $sidebarBtn = $('.sidebar-btn');
     ```
 
   - [25.2](#25.2) <a name='25.2'></a> Cache jQuery lookups.


### PR DESCRIPTION
I updated [Section 25.1](https://github.com/chrisngobanh/javascript#25.1) to include a case with a lookup that has a hyphen in the classname.
The naming convention that I have chosen for this is camelCase.

I felt that this is necessary because it isn't obvious what to do in this case.

Addresses #466 