### PR TITLE
Implicit return + single expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,9 +597,7 @@
     });
 
     // good
-    [1, 2, 3].map((x) => {
-      return x * x;
-    });
+    [1, 2, 3].map(x => x * x);
     ```
 
   - [8.2](#8.2) <a name='8.2'></a> If the function body consists of a single expression, feel free to omit the braces and use the implicit return. Otherwise use a `return` statement.

--- a/README.md
+++ b/README.md
@@ -602,8 +602,6 @@
 
   - [8.2](#8.2) <a name='8.2'></a> If the function body consists of a single expression, feel free to omit the braces and use the implicit return. Otherwise use a `return` statement.
 
-    In case the expression spans over multiple lines, wrap it in parentheses for better readability.
-
   > Why? Syntactic sugar. It reads well when multiple functions are chained together.
 
   > Why not? If you plan on returning an object.
@@ -611,12 +609,6 @@
     ```javascript
     // good
     [1, 2, 3].map(number => `A string containing the ${number}.`);
-
-    // good
-    [1, 2, 3].map(number => (
-      `As time went by, the string containing the ${number} became much ` +
-      'longer. So we needed to break it over multiple lines.'
-    ));
 
     // bad
     [1, 2, 3].map(number => {
@@ -631,7 +623,26 @@
     });
     ```
 
-  - [8.3](#8.3) <a name='8.3'></a> If your function only takes a single argument, feel free to omit the parentheses.
+  - [8.3](#8.3) <a name='8.3'></a> In case the expression spans over multiple lines, wrap it in parentheses for better readability.
+
+  > Why? It shows clearly where the function starts and ends.
+
+    ```js
+    // bad
+    [1, 2, 3].map(number => 'As time went by, the string containing the ' +
+      `${number} became much longer. So we needed to break it over multiple ` +
+      'lines.'
+    );
+
+    // good
+    [1, 2, 3].map(number => (
+      `As time went by, the string containing the ${number} became much ` +
+      'longer. So we needed to break it over multiple lines.'
+    ));
+    ```
+
+
+  - [8.4](#8.4) <a name='8.4'></a> If your function only takes a single argument, feel free to omit the parentheses.
 
     > Why? Less visual clutter.
 

--- a/README.md
+++ b/README.md
@@ -631,6 +631,18 @@
     });
     ```
 
+  - [8.3](#8.3) <a name='8.3'></a> If your function only takes a single argument, feel free to omit the parentheses.
+
+    > Why? Less visual clutter.
+
+    ```js
+    // good
+    [1, 2, 3].map(x => x * x);
+
+    // good
+    [1, 2, 3].reduce((y, x) => x + y);
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 

--- a/README.md
+++ b/README.md
@@ -616,13 +616,13 @@
 
     // bad
     [1, 2, 3].map(number => {
-      let nextNumber = number + 1;
+      const nextNumber = number + 1;
       `A string containing the ${nextNumber}.`;
     });
 
     // good
     [1, 2, 3].map(number => {
-      let nextNumber = number + 1;
+      const nextNumber = number + 1;
       return `A string containing the ${nextNumber}.`;
     });
     ```

--- a/README.md
+++ b/README.md
@@ -602,7 +602,9 @@
     });
     ```
 
-  - [8.2](#8.2) <a name='8.2'></a> If the function body fits on one line and there is only a single argument, feel free to omit the braces and parentheses, and use the implicit return. Otherwise, add the parentheses, braces, and use a `return` statement.
+  - [8.2](#8.2) <a name='8.2'></a> If the function body consists of a single expression, feel free to omit the braces and use the implicit return. Otherwise use a `return` statement.
+
+    In case the expression spans over multiple lines, wrap it in parentheses for better readability.
 
   > Why? Syntactic sugar. It reads well when multiple functions are chained together.
 
@@ -610,12 +612,25 @@
 
     ```javascript
     // good
-    [1, 2, 3].map(x => x * x);
+    [1, 2, 3].map(number => `A string containing the ${number}.`);
 
     // good
-    [1, 2, 3].reduce((total, n) => {
-      return total + n;
-    }, 0);
+    [1, 2, 3].map(number => (
+      `As time went by, the string containing the ${number} became much ` +
+      'longer. So we needed to break it over multiple lines.'
+    ));
+
+    // bad
+    [1, 2, 3].map(number => {
+      let nextNumber = number + 1;
+      `A string containing the ${nextNumber}.`;
+    });
+
+    // good
+    [1, 2, 3].map(number => {
+      let nextNumber = number + 1;
+      return `A string containing the ${nextNumber}.`;
+    });
     ```
 
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@
 
   - [8.4](#8.4) <a name='8.4'></a> If your function only takes a single argument, feel free to omit the parentheses.
 
-    > Why? Less visual clutter.
+  > Why? Less visual clutter.
 
     ```js
     // good

--- a/README.md
+++ b/README.md
@@ -593,11 +593,15 @@
     ```javascript
     // bad
     [1, 2, 3].map(function (x) {
-      return x * x;
+      const y = x + 1;
+      return x * y;
     });
 
     // good
-    [1, 2, 3].map(x => x * x);
+    [1, 2, 3].map((x) => {
+      const y = x + 1;
+      return x * y;
+    });
     ```
 
   - [8.2](#8.2) <a name='8.2'></a> If the function body consists of a single expression, feel free to omit the braces and use the implicit return. Otherwise use a `return` statement.


### PR DESCRIPTION
Fixes #438.

I’ve upgraded the note about argument parens to a new rule – it reads better this way.