### PR TITLE
[React] Fixed Incorrect Class Declaration in Section 10 

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -220,7 +220,7 @@
   - Do not use underscore prefix for internal methods of a React component.
     ```javascript
     // bad
-    React.createClass({
+    class extends React.Component {
       _onClickSubmit() {
         // do stuff
       }


### PR DESCRIPTION
In the bad example for Section 10, the class that was defined was using half ES5 syntax and half ES6 syntax. That means there was a 100% of it producing a syntax error. I fixed it.