### PR TITLE
Recommend exporting `propTypes` as a named export

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -262,7 +262,7 @@
   ```javascript
   import React, { Component, PropTypes } from 'react';
   
-  const propTypes = {
+  export const propTypes = {
     id: PropTypes.number.isRequired,
     url: PropTypes.string.isRequired,
     text: PropTypes.string,


### PR DESCRIPTION
By exporting `propTypes` as a named export *as well* as attaching them to the "class", they can be explicitly imported by tests and other components in a way that aligns with the future ES6 module dependency graph, rather than as an arbitrary property that isn't statically verifiable. Doing both is great imo.

Thoughts?