### PR TITLE
update spelling to clarify JSX rather than JS

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -92,7 +92,7 @@
     ```
 
 ## Alignment
-  - Follow these alignment styles for JS syntax
+  - Follow these alignment styles for JSX syntax
 
     ```javascript
     // bad


### PR DESCRIPTION
Hi, 

Noticed a small issue - the original React alignment section in the readme referred to the following code as "JS syntax" when it highlights use of "JSX syntax". Small difference, but just wanted to request the slight change to offer a little more clarity. 

Thanks and appreciate the style guide - super helpful!!