### PR TITLE
do not export propTypes

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -262,7 +262,7 @@
   ```javascript
   import React, { Component, PropTypes } from 'react';
   
-  export const propTypes = {
+  const propTypes = {
     id: PropTypes.number.isRequired,
     url: PropTypes.string.isRequired,
     text: PropTypes.string,


### PR DESCRIPTION
We decided to stick with the decision to not export `propTypes`, and leave them as only a static property on the default export.

/cc @goatslacker @gilbox