### PR TITLE
Default parameters go last.

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,21 +556,7 @@ Other Style Guides
     }
     ```
 
-  - [7.8](#7.8) <a name='7.8'></a> Always put default parameters last.
-
-    ```javascript
-    // bad
-    function handleThings(opts = {}, name) {
-      // ...
-    }
-
-    // good
-    function handleThings(name, opts = {}) {
-      // ...
-    }
-    ```
-
-  - [7.9](#7.9) <a name='7.9'></a> Avoid side effects with default parameters.
+  - [7.8](#7.8) <a name='7.8'></a> Avoid side effects with default parameters.
 
   > Why? They are confusing to reason about.
 
@@ -585,6 +571,20 @@ Other Style Guides
   count(3); // 3
   count();  // 3
   ```
+
+  - [7.9](#7.9) <a name='7.9'></a> Always put default parameters last.
+
+    ```javascript
+    // bad
+    function handleThings(opts = {}, name) {
+      // ...
+    }
+
+    // good
+    function handleThings(name, opts = {}) {
+      // ...
+    }
+    ```
 
 - [7.10](#7.10) <a name='7.10'></a> Never use the Function constructor to create a new function.
 

--- a/README.md
+++ b/README.md
@@ -556,7 +556,21 @@ Other Style Guides
     }
     ```
 
-  - [7.8](#7.8) <a name='7.8'></a> Avoid side effects with default parameters
+  - [7.8](#7.8) <a name='7.8'></a> Always put default parameters last.
+
+    ```javascript
+    // bad
+    function handleThings(opts = {}, name) {
+      // ...
+    }
+
+    // good
+    function handleThings(name, opts = {}) {
+      // ...
+    }
+    ```
+
+  - [7.9](#7.9) <a name='7.9'></a> Avoid side effects with default parameters.
 
   > Why? They are confusing to reason about.
 
@@ -572,7 +586,7 @@ Other Style Guides
   count();  // 3
   ```
 
-- [7.9](#7.9) <a name='7.9'></a> Never use the Function constructor to create a new function.
+- [7.10](#7.10) <a name='7.10'></a> Never use the Function constructor to create a new function.
 
   > Why? Creating a function in this way evaluates a string similarly to eval(), which opens vulnerabilities.
 


### PR DESCRIPTION
Do you think it's worthwhile to explicitly call out the order when only some parameters have a default? 

[The compiled output is pretty different](https://babeljs.io/repl/#?experimental=true&evaluate=true&loose=false&spec=false&code=%2F%2F%20bad%0Afunction%20handleThings(opts%20%3D%20%7B%7D%2C%20name)%20%7B%0A%20%20%2F%2F%20...%0A%7D%0A%0A%2F%2F%20good%0Afunction%20handleThings(name%2C%20opts%20%3D%20%7B%7D)%20%7B%0A%20%2F%2F%20...%0A%7D). Being new-ish to es6, this seems pretty important to note, but maybe too much of a NSD.