### PR TITLE
Added id-length rule to eslintrc

### DIFF
--- a/packages/eslint-config-airbnb/base/index.js
+++ b/packages/eslint-config-airbnb/base/index.js
@@ -128,6 +128,10 @@ module.exports = {
     'quotes': [
       2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
     ],
+    'id-length': [2, {
+      'min': 2,
+      'properties': 'never'
+    }],
     'camelcase': [2, {               // http://eslint.org/docs/rules/camelcase
       'properties': 'never'
     }],

--- a/packages/eslint-config-airbnb/base/index.js
+++ b/packages/eslint-config-airbnb/base/index.js
@@ -128,7 +128,7 @@ module.exports = {
     'quotes': [
       2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
     ],
-    'id-length': [2, {
+    'id-length': [2, {               // http://eslint.org/docs/rules/id-length
       'min': 2,
       'properties': 'never'
     }],


### PR DESCRIPTION
This helps make sure variable names are longer than 1 character.

Single letter variable names are almost guaranteed to be completely non descriptive, this makes sure our variable names are longer than that.

Documentation on the id-length rule: http://eslint.org/docs/rules/id-length.html