### PR TITLE
Remove JSX from eslint-config-airbnb/base

### DIFF
--- a/packages/eslint-config-airbnb/base/index.js
+++ b/packages/eslint-config-airbnb/base/index.js
@@ -19,8 +19,7 @@ module.exports = {
     'objectLiteralShorthandProperties': true,
     'spread': true,
     'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
+    'templateStrings': true
   },
   'rules': {
     /**

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,13 +1,9 @@
-const reactRules = require('./react');
+const react = require('./react');
 const base = require('./base');
+const defaultsDeep = require('lodash.defaultsdeep');
 
 // clone this so we aren't mutating a module
 const eslintrc = JSON.parse(JSON.stringify(base));
+const reactRules = JSON.parse(JSON.stringify(react));
 
-// manually merge in React rules
-eslintrc.plugins = reactRules.plugins;
-Object.keys(reactRules.rules).forEach(function assignRule(ruleId) {
-  eslintrc.rules[ruleId] = reactRules.rules[ruleId];
-});
-
-module.exports = eslintrc;
+module.exports = defaultsDeep(reactRules, eslintrc);

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -32,5 +32,8 @@
     "eslint-plugin-react": "3.2.3",
     "react": "0.13.3",
     "tape": "4.2.0"
+  },
+  "dependencies": {
+    "lodash.defaultsdeep": "^3.10.0"
   }
 }

--- a/packages/eslint-config-airbnb/react.js
+++ b/packages/eslint-config-airbnb/react.js
@@ -2,7 +2,7 @@ module.exports = {
   'plugins': [
     'react'                          // https://github.com/yannickcr/eslint-plugin-react
   ],
-  rules: {
+  'rules': {
     /**
      * JSX style
      */
@@ -32,5 +32,8 @@ module.exports = {
         'render'
       ]
     }]
+  },
+  'ecmaFeatures': {
+    'jsx': true
   }
 };


### PR DESCRIPTION
Hi,

JSX was present as an `ecmaFeature` in base, so I moved it to the react-specific settings. Also, because I would have had to add another loop for merging `ecmaFeatures`, I decided to just use lodash to merge base and react. All the tests (still) pass.