### PR TITLE
Added clarifying statement to React README

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -217,7 +217,7 @@
     ```
 
 ## Methods
-  - Do not use underscore prefix for internal methods of a React component.
+  - Do not use underscore prefix for internal methods of a React component. Internal methods are private by default, so there is no need to differentiate with an underscore.
     ```javascript
     // bad
     React.createClass({


### PR DESCRIPTION
Added a clarifying statement to explain why the underscore prefix isn't used in React.