### PR TITLE
Fix jsx quotes

### DIFF
--- a/packages/eslint-config-airbnb/base/index.js
+++ b/packages/eslint-config-airbnb/base/index.js
@@ -128,6 +128,7 @@ module.exports = {
     'quotes': [
       2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
     ],
+    'jsx-quotes': [2, 'prefer-double'], // http://eslint.org/docs/rules/jsx-quotes
     'id-length': [2, {               // http://eslint.org/docs/rules/id-length
       'min': 2,
       'properties': 'never'

--- a/packages/eslint-config-airbnb/react.js
+++ b/packages/eslint-config-airbnb/react.js
@@ -8,7 +8,6 @@ module.exports = {
      */
     'react/display-name': 0,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
     'react/jsx-boolean-value': 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-    'react/jsx-quotes': [2, 'double'], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md
     'react/jsx-no-undef': 2,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
     'react/jsx-sort-props': 0,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
     'react/jsx-sort-prop-types': 0,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md


### PR DESCRIPTION
N.B. this pull should be merged after #518 as jsx-quotes is a 1.4.x feature

Now jsx-quotes is included on vanilla eslint and must be used instead of `react/jsx-quotes` that is now deprecated.

Also deprecated rules causes flycheck on emacs to break.