### PR TITLE
Use eslint's jsx-quotes in favor of the deprecated react/jsx-quotes rule

### DIFF
--- a/packages/eslint-config-airbnb/base/index.js
+++ b/packages/eslint-config-airbnb/base/index.js
@@ -128,6 +128,9 @@ module.exports = {
     'quotes': [
       2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
     ],
+    'jsx-quotes': [
+      2, 'prefer-double'             // http://eslint.org/docs/rules/jsx-quotes
+    ],
     'id-length': [2, {               // http://eslint.org/docs/rules/id-length
       'min': 2,
       'properties': 'never'

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "babel-eslint": "4.0.10",
+    "babel-eslint": "4.1.3",
     "babel-tape-runner": "1.2.0",
-    "eslint": "1.1.0",
+    "eslint": "1.5.1",
     "eslint-plugin-react": "3.2.3",
     "react": "0.13.3",
     "tape": "4.2.0"

--- a/packages/eslint-config-airbnb/react.js
+++ b/packages/eslint-config-airbnb/react.js
@@ -8,7 +8,6 @@ module.exports = {
      */
     'react/display-name': 0,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
     'react/jsx-boolean-value': 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-    'react/jsx-quotes': [2, 'double'], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md
     'react/jsx-no-undef': 2,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
     'react/jsx-sort-props': 0,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
     'react/jsx-sort-prop-types': 0,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md


### PR DESCRIPTION
Had to update eslint and babel-eslint to get `npm test` to pass.

See https://github.com/yannickcr/eslint-plugin-react/issues/217

By the way, an easy way to get rid of the deprecation warning for the time being is simply to add

```json
    "jsx-quotes": [
      2, "prefer-double"
    ],
    "react/jsx-quotes": 0
```

to ones local `.eslintrc` file.