### PR TITLE
Clarify proper type casting for Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,7 +1640,7 @@ Other Style Guides
     const totalScore = String(this.reviewScore);
     ```
 
-  - [21.3](#21.3) <a name='21.3'></a> Use `parseInt` for Numbers and always with a radix for type casting.
+  - [21.3](#21.3) <a name='21.3'></a> Numbers: Use `Number` for type casting and `parseInt` always with a radix for parsing strings.
 
     ```javascript
     const inputValue = '4';


### PR DESCRIPTION
Clarifies when to use `Number` vs. `parseInt` for Number type casting, encouraging the proper usage of both.

Fixes: #523

Previously, at item [21.3](https://github.com/airbnb/javascript#21.3), the guide read:
> Use `parseInt` for Numbers and always with a radix for type casting.

However, the example displays:
```javascript
// good
const val = Number(inputValue);

// good
const val = parseInt(inputValue, 10);
```
**Issue**: It is unclear whether `Number` is acceptable because the guide only directly states to use `parseInt` despite the example for `Number`. Indeed, `Number` and `parseInt` are [not interchangeable](https://github.com/airbnb/javascript/issues/523#issuecomment-143229271) and should both be used properply.