### PR TITLE
Create eslint-config-airbnb/legacy to export ES5-only rules

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -4,15 +4,29 @@ This package provides Airbnb's .eslintrc as an extensible shared config.
 
 ## Usage
 
-### With React Style
+We export three ESLint configurations for your usage.
 
-1. `npm install --save-dev eslint-config-airbnb babel-eslint eslint-plugin-react`
+### eslint-config-airbnb
+
+Our default export contains all of our ESLint rules, including EcmaScript 6+
+and React. It requires `eslint`, `babel-eslint`, and `eslint-plugin-react`.
+
+1. `npm install --save-dev eslint-config-airbnb babel-eslint eslint-plugin-react eslint`
 2. add `"extends": "airbnb"` to your .eslintrc
 
-### Without React Style
+### eslint-config-airbnb/base
 
-1. `npm install --save-dev eslint-config-airbnb babel-eslint `
+Lints ES6+ but does not lint React. Requires `eslint` and `babel-eslint`.
+
+1. `npm install --save-dev eslint-config-airbnb babel-eslint eslint`
 2. add `"extends": "airbnb/base"` to your .eslintrc
+
+### eslint-config-airbnb/legacy
+
+Lints ES5 and below. Only requires `eslint`.
+
+1. `npm install --save-dev eslint-config-airbnb eslint`
+2. add `"extends": "airbnb/legacy"` to your .eslintrc
 
 See [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript) and
 the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)

--- a/packages/eslint-config-airbnb/base.js
+++ b/packages/eslint-config-airbnb/base.js
@@ -1,7 +1,8 @@
 module.exports = {
   'extends': [
-    './legacy.js',
-    './rules/es6.js',
+    'eslint-config-airbnb/legacy',
+    'eslint-config-airbnb/rules/es6',
   ],
   'parser': 'babel-eslint',
+  'rules': {}
 };

--- a/packages/eslint-config-airbnb/base.js
+++ b/packages/eslint-config-airbnb/base.js
@@ -1,23 +1,7 @@
 module.exports = {
   'extends': [
-    './rules/best-practices.js',
-    './rules/errors.js',
+    './legacy.js',
     './rules/es6.js',
-    './rules/legacy.js',
-    './rules/node.js',
-    './rules/strict.js',
-    './rules/style.js',
-    './rules/variables.js'
   ],
   'parser': 'babel-eslint',
-  'env': {
-    'browser': true,
-    'node': true,
-    'amd': false,
-    'mocha': false,
-    'jasmine': false
-  },
-  'ecmaFeatures': {},
-  'globals': {},
-  'rules': {}
 };

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   'extends': [
-    // Need to qualify these here for ESLint to resolve them properly.
-    'airbnb/base',
-    'airbnb/rules/react.js'
+    './base.js',
+    './rules/react.js',
   ]
 };

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   'extends': [
-    './base.js',
-    './rules/react.js',
-  ]
+    'eslint-config-airbnb/base',
+    'eslint-config-airbnb/rules/react',
+  ],
+  rules: {}
 };

--- a/packages/eslint-config-airbnb/legacy.js
+++ b/packages/eslint-config-airbnb/legacy.js
@@ -1,12 +1,12 @@
 module.exports = {
   'extends': [
-    './rules/best-practices.js',
-    './rules/errors.js',
-    './rules/legacy.js',
-    './rules/node.js',
-    './rules/strict.js',
-    './rules/style.js',
-    './rules/variables.js'
+    'eslint-config-airbnb/rules/best-practices',
+    'eslint-config-airbnb/rules/errors',
+    'eslint-config-airbnb/rules/legacy',
+    'eslint-config-airbnb/rules/node',
+    'eslint-config-airbnb/rules/strict',
+    'eslint-config-airbnb/rules/style',
+    'eslint-config-airbnb/rules/variables'
   ],
   'env': {
     'browser': true,

--- a/packages/eslint-config-airbnb/legacy.js
+++ b/packages/eslint-config-airbnb/legacy.js
@@ -1,0 +1,21 @@
+module.exports = {
+  'extends': [
+    './rules/best-practices.js',
+    './rules/errors.js',
+    './rules/legacy.js',
+    './rules/node.js',
+    './rules/strict.js',
+    './rules/style.js',
+    './rules/variables.js'
+  ],
+  'env': {
+    'browser': true,
+    'node': true,
+    'amd': false,
+    'mocha': false,
+    'jasmine': false
+  },
+  'ecmaFeatures': {},
+  'globals': {},
+  'rules': {}
+};


### PR DESCRIPTION
This was requested by @thefotios at https://github.com/airbnb/javascript/issues/366#issuecomment-125829744.

