### PR TITLE
Add reasoning for using double quotes in JSX

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -117,6 +117,9 @@
 
 ## Quotes
   - Always use double quotes (`"`) for JSX attributes, but single quotes for all other JS.
+
+  > Why? JSX attributes [can't contain escaped quotes](http://eslint.org/docs/rules/jsx-quotes), so double quotes make conjunctions like `"don't"` easier to type.
+
     ```javascript
     // bad
     <Foo bar='bar' />

--- a/react/README.md
+++ b/react/README.md
@@ -119,6 +119,7 @@
   - Always use double quotes (`"`) for JSX attributes, but single quotes for all other JS.
 
   > Why? JSX attributes [can't contain escaped quotes](http://eslint.org/docs/rules/jsx-quotes), so double quotes make conjunctions like `"don't"` easier to type.
+  > Regular HTML attributes also typically use double quotes instead of single, so JSX attributes mirror this convention.
 
     ```javascript
     // bad


### PR DESCRIPTION
Add reasoning for using double quotes in JSX, since it's the opposite of the recommendation for [JS strings](https://github.com/airbnb/javascript#strings). There may be other reasons as well, but the one added here seems the most compelling to me.