### PR TITLE
Allow '==' to check for null and undefined in one go.

### DIFF
--- a/packages/eslint-config-airbnb/rules/best-practices.js
+++ b/packages/eslint-config-airbnb/rules/best-practices.js
@@ -17,7 +17,7 @@ module.exports = {
     // enforces consistent newlines before or after dots
     'dot-location': 0,
     // require the use of === and !==
-    'eqeqeq': 2,
+    'eqeqeq': [2, 'allow-null'],
     // make sure for-in loops have an if statement
     'guard-for-in': 2,
     // disallow the use of alert, confirm, and prompt


### PR DESCRIPTION
Using `==` against `null` is a common pattern (see [here](https://github.com/chenglou/react-motion/blob/3aa46cbbc2c136cbbf535538c58b2161978eef6f/src/stripStyle.js) for example). Since ESLint caters to it, should it not be allowed? Relevant ESLint documentation: http://eslint.org/docs/rules/eqeqeq