### PR TITLE
Prohibit Padded Blocks and Allow Comments in the First Line of a Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,7 +1248,7 @@ Other Style Guides
     }
     ```
 
-  - [17.2](#17.2) <a name='17.2'></a> Use `//` for single line comments. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment.
+  - [17.2](#17.2) <a name='17.2'></a> Use `//` for single line comments. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment unless it's on the first line of a block.
 
     ```javascript
     // bad
@@ -1271,6 +1271,14 @@ Other Style Guides
     function getType() {
       console.log('fetching type...');
 
+      // set the default type to 'no type'
+      const type = this._type || 'no type';
+
+      return type;
+    }
+
+    // also good
+    function getType() {
       // set the default type to 'no type'
       const type = this._type || 'no type';
 

--- a/README.md
+++ b/README.md
@@ -1511,6 +1511,34 @@ Other Style Guides
     return arr;
     ```
 
+  - [18.8](#18.8) <a name='18.8'></a> Do not pad your blocks with blank lines.
+
+    ```javascript
+    // bad
+    function bar() {
+
+      console.log(foo);
+
+    }
+
+    // also bad
+    function bar() {
+
+      console.log(foo);
+    }
+
+    // still bad
+    function bar() {
+      console.log(foo);
+
+    }
+
+    // good
+    function bar() {
+      console.log(foo);
+    }
+    ```
+
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1530,19 +1530,23 @@ Other Style Guides
     }
 
     // also bad
-    function bar() {
+    if (baz) {
 
-      console.log(foo);
-    }
-
-    // still bad
-    function bar() {
+      console.log(qux);
+    } else {
       console.log(foo);
 
     }
 
     // good
     function bar() {
+      console.log(foo);
+    }
+
+    // good
+    if (baz) {
+      console.log(qux);
+    } else {
       console.log(foo);
     }
     ```


### PR DESCRIPTION
In #483, @justjake says that we should amend the style guide to allow single line comments in the first line of a block. I updated 17.2 with this change.

In addition, our ESLint config file prohibits padded blocks, so I decided to make a section 18.8 to address that.