### PR TITLE
`export default` should not be inline with the class declaration

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -274,7 +274,7 @@
     text: 'Hello World',
   };
   
-  export default class Link extends Component {
+  class Link extends Component {
     static methodsAreOk() {
       return true;
     }
@@ -286,6 +286,8 @@
   
   Link.propTypes = propTypes;
   Link.defaultProps = defaultProps;
+  
+  export default Link;
   ```
 
   - Ordering for React.createClass:


### PR DESCRIPTION
When there are static variables like `propTypes` and `defaultProps`, we shouldn't export them until we have actually set them onto the `Component`. This may change if the current ES7 proposal for static class properties gets accepts, and we update to support it.