### PR TITLE
eslint: Add missing `space-before-keywords` rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -88,8 +88,10 @@ module.exports = {
     'semi': [2, 'always'],
     // sort variables within the same declaration block
     'sort-vars': 0,
+    // require a space before certain keywords
+    'space-before-keywords': [2, 'always'],
     // require a space after certain keywords
-    'space-after-keywords': 2,
+    'space-after-keywords': [2, 'always'],
     // require or disallow space before blocks
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis


### PR DESCRIPTION
All examples in README.md seem to agree on avoiding missing whitespaces before keywords such as:

```js
if (cond) {
}else {       // no space before 'else'
}

try {
}catch (e) {  // no space before 'catch'
}
```

This patchs adds the `space-before-keywords` rule as an error (as is `space-after-keywords` already).