### PR TITLE
eslint: Fix `no-mixed-spaces-and-tabs` turn off

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -49,7 +49,7 @@ module.exports = {
     // disallow if as the only statement in an else block
     'no-lonely-if': 0,
     // disallow mixed spaces and tabs for indentation
-    'no-mixed-spaces-and-tabs': 0,
+    'no-mixed-spaces-and-tabs': 2,
     // disallow multiple empty lines
     'no-multiple-empty-lines': [2, {'max': 2}],
     // disallow nested ternary expressions


### PR DESCRIPTION
Currently the way the rule is defined, mixing spaces and tabulations in
indentation is allowed. However, the comments and documents seems to say
the opposite.

This patchs turns the rule on so mixing spaces and tabs is NOT allowed.

Fixes: #539