### PR TITLE
Allow flow type comments

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -107,7 +107,7 @@ module.exports = {
     // require or disallow a space immediately following the // or /* in a comment
     'spaced-comment': [2, 'always', {
       'exceptions': ['-', '+'],
-      'markers': ['=', '!']           // space here to support sprockets directives
+      'markers': ['=', '!', ':']           // space here to support sprockets directives
     }],
     // require regex literals to be wrapped in parentheses
     'wrap-regex': 0


### PR DESCRIPTION
Examples:

```js
/*: (x: number): boolean */
function foo(x) {
  return (x > 2);
}
```

```js
function foo(x /*: number */) /*: boolean */ {
  return (x > 2);
}
```