### PR TITLE
[eslint] remove id length rule (too much nutrage)

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -21,7 +21,7 @@ module.exports = {
     // enforces use of function declarations or expressions
     'func-style': 0,
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    'id-length': [2, {'min': 2, 'properties': 'never'}],
+    'id-length': 0,
     // this option sets a specific tab width for your code
     'indent': [2, 2],
     // specify whether double or single quotes should be used in JSX attributes


### PR DESCRIPTION
Will close: #567 #563, #510 

It seems like everyone is nutraged about one letter variable names. I know I am. Let's just turn this rule off and forget we ever thought it was a good idea. If you find yourself having a problem with one-letter variable names on your team, you can easily re-enable this rule.

@ljharb @hshoff 