### PR TITLE
update `eslint`

### DIFF
--- a/packages/eslint-config-airbnb/base.js
+++ b/packages/eslint-config-airbnb/base.js
@@ -3,6 +3,5 @@ module.exports = {
     'eslint-config-airbnb/legacy',
     'eslint-config-airbnb/rules/es6',
   ],
-  'parser': 'babel-eslint',
   'rules': {}
 };

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "babel-eslint": "4.1.3",
     "babel-tape-runner": "1.2.0",
     "eslint": "^1.8.0",
     "eslint-plugin-react": "^3.7.1",

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "babel-eslint": "4.1.3",
     "babel-tape-runner": "1.2.0",
-    "eslint": "1.5.1",
-    "eslint-plugin-react": "3.4.2",
-    "react": "0.13.3",
-    "tape": "4.2.0"
+    "eslint": "^1.8.0",
+    "eslint-plugin-react": "^3.7.1",
+    "react": "^0.13.3",
+    "tape": "^4.2.2"
   }
 }

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -31,5 +31,8 @@
     "eslint-plugin-react": "^3.7.1",
     "react": "^0.13.3",
     "tape": "^4.2.2"
+  },
+  "peerDependencies": {
+    "eslint": ">=1.0.0"
   }
 }

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'parser': 'babel-eslint',
   'plugins': [
     'react'
   ],

--- a/packages/eslint-config-airbnb/test/test-react-order.js
+++ b/packages/eslint-config-airbnb/test/test-react-order.js
@@ -29,8 +29,7 @@ ${body}
 
 test('validate react prop order', t => {
   t.test('make sure our eslintrc has React linting dependencies', t => {
-    t.plan(2);
-    t.equal(baseConfig.parser, 'babel-eslint', 'uses babel-eslint');
+    t.plan(1);
     t.equal(reactRules.plugins[0], 'react', 'uses eslint-plugin-react');
   });
 


### PR DESCRIPTION
This updates `eslint`, `eslint-plugin-react`, and `tape` to the latest version. It also removes the `babel-eslint` dependency, which fixes #565.