### PR TITLE
Allow multiple stateless components in a single file

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -91,7 +91,7 @@ module.exports = {
     'react/no-is-mounted': 2,
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-multi-comp': [2, {'ignoreStateless': false}],
+    'react/no-multi-comp': [2, {'ignoreStateless': true}],
     // Prevent usage of setState
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
     'react/no-set-state': 0,

--- a/react/README.md
+++ b/react/README.md
@@ -21,6 +21,7 @@
 ## Basic Rules
 
   - Only include one React component per file.
+    - However, multiple [Stateless, or Pure, Components](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions) are allowed per file. eslint rule: [`react/no-multi-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md#ignorestateless).
   - Always use JSX syntax.
   - Do not use `React.createElement` unless you're initializing the app from a file that is not JSX.
 


### PR DESCRIPTION
IDK if you want it, but we had linting errors after upgrading eslint-plugin-react.

This change allows multiple stateless components in a single file.

Requires 3.80 of eslint-plugin-react
https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#380---2015-11-07