### PR TITLE
[eslint] Enforce rule 18.5

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -50,8 +50,8 @@ module.exports = {
     'no-lonely-if': 0,
     // disallow mixed spaces and tabs for indentation
     'no-mixed-spaces-and-tabs': 2,
-    // disallow multiple empty lines
-    'no-multiple-empty-lines': [2, {'max': 2}],
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, {'max': 2, 'maxEOF': 1}],
     // disallow nested ternary expressions
     'no-nested-ternary': 2,
     // disallow use of the Object constructor


### PR DESCRIPTION
Rule [18.5][1] states that files shall end with a single newline
character. Until now, this was not checked because there was no such
option in eslint.

Since version 1.8.0, eslint provides the ability to do that. See [pull
request on eslint][2] for details on implementation and usage. Let's use
it in airbnb eslint plugin now!

[1]: https://github.com/airbnb/javascript#18.5
[2]: https://github.com/eslint/eslint/pull/4266