### PR TITLE
Use require.resolve to allow nested extend

### DIFF
--- a/packages/eslint-config-airbnb/base.js
+++ b/packages/eslint-config-airbnb/base.js
@@ -2,6 +2,6 @@ module.exports = {
   'extends': [
     'eslint-config-airbnb/legacy',
     'eslint-config-airbnb/rules/es6',
-  ],
+  ].map(require.resolve),
   'rules': {}
 };

--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -2,6 +2,6 @@ module.exports = {
   'extends': [
     'eslint-config-airbnb/base',
     'eslint-config-airbnb/rules/react',
-  ],
+  ].map(require.resolve),
   rules: {}
 };

--- a/packages/eslint-config-airbnb/legacy.js
+++ b/packages/eslint-config-airbnb/legacy.js
@@ -7,7 +7,7 @@ module.exports = {
     'eslint-config-airbnb/rules/strict',
     'eslint-config-airbnb/rules/style',
     'eslint-config-airbnb/rules/variables'
-  ],
+  ].map(require.resolve),
   'env': {
     'browser': true,
     'node': true,


### PR DESCRIPTION
By default eslint always resolves files in `extends` relative to the top-level project. Using `require.resolve` converts the references to absolute paths. Example:

```
node_modules/
  eslint-config-groupon/
    node_modules/
      eslint-config-airbnb/
        index.js # refers to 'eslint-config-airbnb/base'
```

By default eslint will look for `eslint-config-airbnb/base` in the top-level node_modules directory instead of one level down. By using `require.resolve` the "normal" npm resolution rules apply.

We use this approach in `eslint-config-groupon`. This change would allow us to get rid of [the uglier parts](https://github.com/groupon/javascript/blob/master/linters/eslint-config-groupon/legacy.js#L28-L48) in that repo.