### PR TITLE
Avoid the word "mutate" while explaining `const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Other Style Guides
 
   - [2.1](#2.1) <a name='2.1'></a> Use `const` for all of your references; avoid using `var`.
 
-  > Why? This ensures that you can't reassign your references (mutation), which can lead to bugs and difficult to comprehend code.
+  > Why? This ensures that you can't reassign your references, which can lead to bugs and difficult to comprehend code.
 
     ```javascript
     // bad
@@ -101,7 +101,7 @@ Other Style Guides
     const b = 2;
     ```
 
-  - [2.2](#2.2) <a name='2.2'></a> If you must mutate references, use `let` instead of `var`.
+  - [2.2](#2.2) <a name='2.2'></a> If you must reassign references, use `let` instead of `var`.
 
   > Why? `let` is block-scoped rather than function-scoped like `var`.
 


### PR DESCRIPTION
Since a common misconception about the `const` keyword in ES2015 is that it prohibits mutation of values when in fact it only prohibits mutation of references I think it’s clearer to avoid this word in this context completely. When we talk about mutability and immutability in JS we almost always mean _values_ and not _references_. So although the wording in this section is correct I think it should be re-phrased to avoid confusion. :)