### PR TITLE
Fix example for section 7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Other Style Guides
 - [7.11](#7.11) <a name="7.11"></a> Spacing in a function signature.
 
   > Why? Consistency is good, and you shouldn’t have to add or remove a space when adding or removing a name.
+  
   ```javascript
   // bad
   const f = function(){};


### PR DESCRIPTION
The missing newline caused the markdown parser to misinterpret the beginning and end of the code block.