### PR TITLE
Don't enforce spaces inside curly braces for nested objects/arrays

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -67,8 +67,8 @@ module.exports = {
     'no-underscore-dangle': 0,
     // disallow the use of Boolean literals in conditional expressions
     'no-unneeded-ternary': 0,
-    // require padding inside curly braces
-    'object-curly-spacing': [2, 'always'],
+    // require padding inside curly braces except for nested objects/arrays
+    'object-curly-spacing': [2, "always", { 'objectsInObjects': false, 'arraysInObjects': false },
     // allow just one var statement per function
     'one-var': [2, 'never'],
     // require assignment operator shorthand where possible or prohibit it entirely


### PR DESCRIPTION
I couldn't find any examples around the project but I have a feeling this syntax is pretty standard across the web.

```javascript
var obj = { "foo": { "baz": 1, "bar": 2 }};
// or
var obj = { "foo": [ "baz", "bar" ]};
```
instead of 
```javascript
var obj = { "foo": { "baz": 1, "bar": 2 } };
var obj = { "foo": [ "baz", "bar" ] };
```
http://eslint.org/docs/rules/object-curly-spacing.html#exceptions