### PR TITLE
Fix syntax highlighting in section 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,12 +1164,12 @@ Other Style Guides
 
   eslint rules: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq.html).
 
-    + **Objects** evaluate to **true**
-    + **Undefined** evaluates to **false**
-    + **Null** evaluates to **false**
-    + **Booleans** evaluate to **the value of the boolean**
-    + **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
-    + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
+  + **Objects** evaluate to **true**
+  + **Undefined** evaluates to **false**
+  + **Null** evaluates to **false**
+  + **Booleans** evaluate to **the value of the boolean**
+  + **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
+  + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
 
     ```javascript
     if ([0]) {


### PR DESCRIPTION
This is a fix for broken code blocks in section 15:

![bildschirmfoto 2015-12-09 um 10 53 25](https://cloud.githubusercontent.com/assets/485033/11682096/1e9c6b3c-9e63-11e5-99f1-ee6f5831aa24.png)
