### PR TITLE
Require space before/after arrow function's arrow (arrow-spacing)

### DIFF
--- a/packages/eslint-config-airbnb/rules/es6.js
+++ b/packages/eslint-config-airbnb/rules/es6.js
@@ -25,7 +25,8 @@ module.exports = {
     // require parens in arrow function arguments
     'arrow-parens': 0,
     // require space before/after arrow function's arrow
-    'arrow-spacing': 0,
+    // https://github.com/eslint/eslint/blob/master/docs/rules/arrow-spacing.md
+    'arrow-spacing': [2, { 'before': true, 'after': true }],
     // verify super() callings in constructors
     'constructor-super': 0,
     // enforce the spacing around the * in generator functions


### PR DESCRIPTION
Enable [arrow-spacing](http://eslint.org/docs/rules/arrow-spacing.html) rule, code with space before/after arrow function's arrow is easier to read:
```js
() => {};
(a) => {};
a => a;
() => {'\n'};
()=> {};     /*error Missing space before =>*/
() =>{};     /*error Missing space after =>*/
(a)=> {};    /*error Missing space before =>*/
(a) =>{};    /*error Missing space after =>*/
a =>a;       /*error Missing space after =>*/
a=> a;       /*error Missing space before =>*/
()=> {'\n'}; /*error Missing space before =>*/
() =>{'\n'}; /*error Missing space after =>*/
```