### PR TITLE
Remove deprecated react/jsx-quotes

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -27,9 +27,6 @@ module.exports = {
     // Disallow undeclared variables in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
     'react/jsx-no-undef': 2,
-    // Enforce quote style for JSX attributes
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quote.md
-    'react/jsx-quotes': [2, 'double'],
     // Enforce propTypes declarations alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
     'react/jsx-sort-prop-types': 0,

--- a/react/README.md
+++ b/react/README.md
@@ -128,7 +128,7 @@
   > Why? JSX attributes [can't contain escaped quotes](http://eslint.org/docs/rules/jsx-quotes), so double quotes make conjunctions like `"don't"` easier to type.
   > Regular HTML attributes also typically use double quotes instead of single, so JSX attributes mirror this convention.
 
-  eslint rules: [`react/jsx-quotes`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md).
+  eslint rules: [`jsx-quotes`](http://eslint.org/docs/rules/jsx-quotes).
 
     ```javascript
     // bad


### PR DESCRIPTION
This rule is deprecated, but was reintroduced in #618. Running eslint with this config now prints:

```
The react/jsx-quotes rule is deprecated. Please use the jsx-quotes rule instead.
```

The correct rule is already enforced [here](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/style.js#L29).