### PR TITLE
Export default with class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
-# Airbnb JavaScript Style Guide() {
+# Hudl JavaScript Style Guide() {
 
 *A mostly reasonable approach to JavaScript*
+
+Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
 
 [For the ES5-only guide click here](es5/).
 

--- a/react/README.md
+++ b/react/README.md
@@ -89,6 +89,11 @@
     }
  
     export default ReservationCard;
+
+
+    // better
+    export default class ReservationCard extends React.Component {
+    }
     ```
 
 ## Alignment


### PR DESCRIPTION
In the style guide, it says not to use displayName, which I am fine with, but it seems like it discourages the use of `export default` when you can still name a class with
`export default class SomeComponent extends Component {}`.

I think this syntax is better than 
```javascript
class Something {}
export default Something
```