### PR TITLE
Method chaining with prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,18 +807,21 @@ Other Style Guides
 
     ```javascript
     // bad
+    function Jedi() {}
+
     Jedi.prototype.jump = function () {
       this.jumping = true;
-      return true;
+      return this;
     };
 
     Jedi.prototype.setHeight = function (height) {
       this.height = height;
+      return this;
     };
 
     const luke = new Jedi();
-    luke.jump(); // => true
-    luke.setHeight(20); // => undefined
+    luke.jump()
+      .setHeight(20);
 
     // good
     class Jedi {


### PR DESCRIPTION
Example provided in 9.3  looks like we can not use method chaining with prototype. It's actually possible, so we should put the two different ways.(oh, and I added a function constructor).