### PR TITLE
[eslint config] [breaking] enable `quote-props` rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,28 @@ Other Style Guides
     };
     ```
 
+  - [3.8](#3.8) <a name="3.8"></a> Only quote properties that are invalid identifiers.
+
+  > Why? In general we consider it subjectively easier to read. It improves syntax highlighting, and is also more easily optimized by many JS engines.
+
+  eslint rules: [`quote-props`](http://eslint.org/docs/rules/quote-props.html).
+
+  ```javascript
+  // bad
+  const bad = {
+    'foo': 3,
+    'bar': 4,
+    'data-blah': 5,
+  };
+
+  // good
+  const good = {
+    foo: 3,
+    bar: 4,
+    'data-blah': 5,
+  };
+  ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Arrays

--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -85,7 +85,8 @@ module.exports = {
     // enforce padding within blocks
     'padded-blocks': [2, 'never'],
     // require quotes around object literal property names
-    'quote-props': 0,
+    // http://eslint.org/docs/rules/quote-props.html
+    'quote-props': [2, 'as-needed', { 'keywords': true, 'unnecessary': true, 'numbers': false }],
     // specify whether double or single quotes should be used
     'quotes': [2, 'single', 'avoid-escape'],
     // require identifiers to match the provided regular expression


### PR DESCRIPTION
This is the rule we follow at Airbnb, but the styleguide and linter plugin haven't been enforcing it.