### PR TITLE
Sort react/prefer-es6-class alphabetically

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -54,6 +54,9 @@ module.exports = {
     // Prevent usage of unknown DOM property
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
     'react/no-unknown-property': 2,
+    // Require ES6 class declarations over React.createClass
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
+    'react/prefer-es6-class': [2, 'always'],
     // Prevent missing props validation in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
     'react/prop-types': 2,
@@ -85,8 +88,5 @@ module.exports = {
       assignment: true,
       return: true
     }],
-    // Require ES6 class declarations over React.createClass
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
-    'react/prefer-es6-class': [2, 'always'],
   }
 };


### PR DESCRIPTION
All of the other rules in this file are in alphabetical order, but this
one was added by c98990c0f out of order at the end. Keeping these in
alphabetical order will help developers find the rules that they are
looking for.