### PR TITLE
[eslint-config] [minor] Enable react/no-is-mounted rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -48,6 +48,9 @@ module.exports = {
     // Prevent usage of setState in componentDidUpdate
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
     'react/no-did-update-set-state': [2, 'allow-in-func'],
+    // Prevent usage of isMounted
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
+    'react/no-is-mounted': 2,
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
     'react/no-multi-comp': 2,

--- a/react/README.md
+++ b/react/README.md
@@ -15,6 +15,7 @@
   1. [Tags](#tags)
   1. [Methods](#methods)
   1. [Ordering](#ordering)
+  1. [`isMounted`](#ismounted)
 
 ## Basic Rules
 
@@ -333,5 +334,13 @@
   1. render
 
   eslint rules: [`react/sort-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md).
+
+## `isMounted`
+
+  [`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and is on its way to being officially deprecated. Its use should be avoided.
+
+  [anti-pattern]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
+
+  eslint rules: [`react/no-is-mounted`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md).
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
isMounted is an anti-pattern [0], is not available when using ES6
classes, and is on its way to being officially deprecated.
eslint-plugin-react recently added the react/no-is-mounted rule in
3.12.0 that prevents its use.

[0]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html

Finishes #633