### PR TITLE
Permit strict mode

### DIFF
--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   'extends': [
     'eslint-config-airbnb/base',
+    'eslint-config-airbnb/rules/strict',
     'eslint-config-airbnb/rules/react',
   ].map(require.resolve),
   rules: {}

--- a/packages/eslint-config-airbnb/legacy.js
+++ b/packages/eslint-config-airbnb/legacy.js
@@ -4,7 +4,6 @@ module.exports = {
     'eslint-config-airbnb/rules/errors',
     'eslint-config-airbnb/rules/legacy',
     'eslint-config-airbnb/rules/node',
-    'eslint-config-airbnb/rules/strict',
     'eslint-config-airbnb/rules/style',
     'eslint-config-airbnb/rules/variables'
   ].map(require.resolve),


### PR DESCRIPTION
Permit strict mode for legacy configuration as this mode is not intended to be used with Babel.