### PR TITLE
Define a max line length of 100 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,6 +1692,31 @@ Other Style Guides
     // good
     const foo = { clark: 'kent' };
     ```
+  - [18.12](#18.12) <a name='18.12'></a> Avoid having lines of code that are longer than 100 characters (including whitespace).
+  > Why? This ensures readability and maintainability.
+
+  eslint rules: [`max-len`](http://eslint.org/docs/rules/max-len.html).
+
+    ```javascript
+  // bad
+  const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. Whatever wizard constrains a helpful ally. The counterpart ascends!';
+
+  // bad
+  $.ajax({ method: 'POST', url: 'https://airbnb.com/', data: { name: 'John' } }).done(() => console.log('Congratulations!')).fail(() => console.log('You have failed this city.'));
+
+  // good
+  const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. ' +
+    'Whatever wizard constrains a helpful ally. The counterpart ascends!';
+
+  // good
+  $.ajax({
+    method: 'POST',
+    url: 'https://airbnb.com/',
+    data: { name: 'John' },
+  })
+    .done(() => console.log('Congratulations!'))
+    .fail(() => console.log('You have failed this city.'));
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Other Style Guides
     const name = 'Capt. Janeway';
     ```
 
-  - [6.2](#6.2) <a name='6.2'></a> Strings longer than 100 characters should be written across multiple lines using string concatenation.
+  - [6.2](#6.2) <a name='6.2'></a> Strings that cause the line to go over 100 characters should be written across multiple lines using string concatenation.
   - [6.3](#6.3) <a name='6.3'></a> Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40).
 
     ```javascript

--- a/linters/.jshintrc
+++ b/linters/.jshintrc
@@ -34,8 +34,8 @@
   // Prohibit use of a variable before it is defined.
   "latedef": true,
 
-  // Enforce line length to 80 characters
-  "maxlen": 80,
+  // Enforce line length to 100 characters
+  "maxlen": 100,
 
   // Require capitalized names for constructor functions.
   "newcap": true,

--- a/packages/eslint-config-airbnb/rules/legacy.js
+++ b/packages/eslint-config-airbnb/rules/legacy.js
@@ -2,8 +2,6 @@ module.exports = {
   'rules': {
     // specify the maximum depth that blocks can be nested
     'max-depth': [0, 4],
-    // specify the maximum length of a line in your program
-    'max-len': [0, 80, 4],
     // limits the number of parameters that can be used in the function declaration.
     'max-params': [0, 3],
     // specify the maximum number of statement allowed in a function

--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -34,6 +34,8 @@ module.exports = {
     'lines-around-comment': 0,
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     'linebreak-style': 0,
+    // specify the maximum length of a line in your program
+    "max-len": [2, 100, 4],
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': 0,
     // require a capital letter for constructors

--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -35,7 +35,17 @@ module.exports = {
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     'linebreak-style': 0,
     // specify the maximum length of a line in your program
-    "max-len": [2, 100, 4],
+    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
+    'max-len': [2, {
+      'code': 100,
+      'comments': 100,
+      'commentLength': 100,
+      'tabWidth': 2,
+      'ignoreUrls': false,
+      'ignorePattern': null,
+      'ignoreTrailingComments': false,
+      'ignoreComments': false
+    }],
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': 0,
     // require a capital letter for constructors


### PR DESCRIPTION
Taking over #510 
Addresses #509 

This PR adds section 18.12, which defines a limit for the length of a line to be **100 characters (including whitespace)**. This number was agreed upon in #510 and is also the line length defined in the Ruby style guide.

I enabled ESLint rule [max-len](http://eslint.org/docs/rules/max-len.html) to enforce this, as well as updated `.jshintrc`.

I also updated section 6.2 to recognize the newly defined line length.

Something to discuss: I put this new rule in the Whitespace section (18), but should it have its own section? 
The Ruby style guide has it in its section, separate from the Whitespace section.