### PR TITLE
Link newer ESLint rule (namely comma-dangle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1774,7 +1774,7 @@ Other Style Guides
 
   - [19.2](#19.2) <a name='19.2'></a> Additional trailing comma: **Yup.**
 
-    eslint rules: [`no-comma-dangle`](http://eslint.org/docs/rules/no-comma-dangle.html).
+    eslint rules: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html).
 
     > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](es5/README.md#commas) in legacy browsers.
 


### PR DESCRIPTION
The "no-comma-dangle" rule was deprecated in favor or "comma-dangle" in ESLint v1.0, but the older rule is still linked.

See [`no-comma-dangle`](http://eslint.org/docs/rules/no-comma-dangle.html), [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle), and [line 4 of packages/eslint-config-airbnb/rules/errors.js](https://github.com/airbnb/javascript/blob/88d508400941600a71f45a245748346af9e62d1d/packages/eslint-config-airbnb/rules/errors.js#L4).