### PR TITLE
missing 's', create(s) under Method

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -267,7 +267,7 @@
 
   - Bind event handlers for the render method in the constructor.
 
-  > Why? A bind call in a the render path create a brand new function on every single render.
+  > Why? A bind call in a the render path creates a brand new function on every single render.
 
   eslint rules: [`react/jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md).
 


### PR DESCRIPTION
found this missing 's', grammar fixes.