### PR TITLE
Use Array.from to convert arguments to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ Other Style Guides
     ```javascript
     // bad
     function concatenateAll() {
-      const args = Array.prototype.slice.call(arguments);
+      const args = Array.from(arguments);
       return args.join('');
     }
 


### PR DESCRIPTION
You recommended that technique before. Or is that hurting the point? Is `prototype.slice.call` intentionally used to make the bad example worse?