### PR TITLE
Ignore URLs in max-len

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -37,7 +37,7 @@ module.exports = {
     // specify the maximum length of a line in your program
     // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
     'max-len': [2, 100, 2, {
-      'ignoreUrls': false,
+      'ignoreUrls': true,
       'ignoreComments': false
     }],
     // specify the maximum depth callbacks can be nested


### PR DESCRIPTION
How do you get around this situation?

```js
// https://github.com/webpack/css-loader/tree/1298d2b38c4770dbf853ff1eed632fe239881cc2#css-modules
const foo = 'bar';
```

I could use a URL shortener, but that would remove the information from the URL.