### PR TITLE
Remove whitespace before function call parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1457,17 +1457,17 @@ Other Style Guides
 
     ```javascript
     // bad
-    function () {
+    function() {
     ∙∙∙∙const name;
     }
 
     // bad
-    function () {
+    function() {
     ∙const name;
     }
 
     // good
-    function () {
+    function() {
     ∙∙const name;
     }
     ```


### PR DESCRIPTION
Having a space here is a bit distracting for 2 reasons:

1. This rule is about using soft tabs over tabs
2.  `// good` goes against violation of [18.3](https://github.com/airbnb/javascript#18.3) that says "*Place no space before the argument list in function calls and declarations.*"