### PR TITLE
Update "Comparison Operators & Equality" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,9 +1250,9 @@ Other Style Guides
     + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
 
     ```javascript
-    if ([0]) {
+    if ([0] && []) {
       // true
-      // An array is an object, objects evaluate to true
+      // An array (even an empty one) is an object, objects will evaluate to true
     }
     ```
 


### PR DESCRIPTION
The guide should be more clear that [] is truthy because arrays are objects. As is, a reader could be confused about this because an empty string will be evaluated as false and it's possible (but not a good idea) to access a string using array-like syntax. It also doesn't help that this array-like syntax is in line with other languages like C where strings ARE arrays, further adding to potential confusion.