### PR TITLE
Add `prefer-arrow-callback` to ES6 Rules.

### DIFF
--- a/packages/eslint-config-airbnb/rules/es6.js
+++ b/packages/eslint-config-airbnb/rules/es6.js
@@ -42,6 +42,8 @@ module.exports = {
     // require method and property shorthand syntax for object literals
     // https://github.com/eslint/eslint/blob/master/docs/rules/object-shorthand.md
     'object-shorthand': [2, 'always'],
+    // suggest using arrow functions as callbacks
+    'prefer-arrow-callback': 2,
     // suggest using of const declaration for variables that are never modified after declared
     'prefer-const': 2,
     // suggest using the spread operator instead of .apply()


### PR DESCRIPTION
This prefers arrow functions as described in https://github.com/airbnb/javascript#8.1

Fixes #665