### PR TITLE
arrow-parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ Other Style Guides
 
     // good
     let sum = 0;
-    numbers.forEach((num) => sum += num);
+    numbers.forEach(num => sum += num);
     sum === 15;
 
     // best (use the functional force)


### PR DESCRIPTION
Example should comply with rule `arrow-parens`