### PR TITLE
Fix syntax issue on createClass example

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -34,7 +34,7 @@
     ```javascript
     // bad
     const Listing = React.createClass({
-      render() {
+      render: function() {
         return <div />;
       }
     });


### PR DESCRIPTION
Since `createClass` gets an object, you can't use the `method() {}` syntax, but `{method: function()}`.