### PR TITLE
Fixed minor capitalization change in Hoisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,7 +1196,7 @@ Other Style Guides
       var declaredButNotAssigned = true;
     }
 
-    // The interpreter is hoisting the variable
+    // the interpreter is hoisting the variable
     // declaration to the top of the scope,
     // which means our example could be rewritten as:
     function example() {


### PR DESCRIPTION
Not sure if it's an actual fix, but just noticed this was the only comment that had capitalization that wasn't a proper noun.