### PR TITLE
Migrate to eslint@2.0.0-beta

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -39,13 +39,13 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "babel-tape-runner": "1.2.0",
-    "eslint": "^1.10.3",
+    "eslint": "^2.0.0-beta",
     "eslint-plugin-react": "^3.12.0",
     "react": "^0.13.3",
     "tape": "^4.2.2",
     "parallelshell": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=1.0.0"
+    "eslint": ">=2.0.0-beta "
   }
 }

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -39,13 +39,13 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "babel-tape-runner": "1.2.0",
-    "eslint": "^2.0.0-beta",
+    "eslint": "^2.0.0-rc0",
     "eslint-plugin-react": "^3.12.0",
     "react": "^0.13.3",
     "tape": "^4.2.2",
     "parallelshell": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=2.0.0-beta "
+    "eslint": ">=2.0.0-rc0 "
   }
 }

--- a/packages/eslint-config-airbnb/rules/best-practices.js
+++ b/packages/eslint-config-airbnb/rules/best-practices.js
@@ -29,8 +29,6 @@ module.exports = {
     // disallow else after a return in an if
     'no-else-return': 2,
     // disallow use of labels for anything other then loops and switches
-    'no-empty-label': 2,
-    // disallow comparisons to null without a type-checking operator
     'no-eq-null': 0,
     // disallow use of eval()
     'no-eval': 2,

--- a/packages/eslint-config-airbnb/rules/es6.js
+++ b/packages/eslint-config-airbnb/rules/es6.js
@@ -2,24 +2,27 @@ module.exports = {
   'env': {
     'es6': false
   },
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': true,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'restParams': true,
-    'spread': true,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module',
+    'ecmaFeatures': {
+      'arrowFunctions': true,
+      'blockBindings': true,
+      'classes': true,
+      'defaultParams': true,
+      'destructuring': true,
+      'forOf': true,
+      'generators': false,
+      'objectLiteralComputedProperties': true,
+      'objectLiteralDuplicateProperties': false,
+      'objectLiteralShorthandMethods': true,
+      'objectLiteralShorthandProperties': true,
+      'restParams': true,
+      'spread': true,
+      'superInFunctions': true,
+      'templateStrings': true,
+      'jsx': true
+    }
   },
   'rules': {
     // enforces no braces where they can be omitted

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -2,8 +2,10 @@ module.exports = {
   'plugins': [
     'react'
   ],
-  'ecmaFeatures': {
-    'jsx': true
+  'parserOptions': {
+    'ecmaFeatures': {
+      'jsx': true
+    }
   },
   // View link below for react rules documentation
   // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules

--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -98,10 +98,8 @@ module.exports = {
     'semi': [2, 'always'],
     // sort variables within the same declaration block
     'sort-vars': 0,
-    // require a space before certain keywords
-    'space-before-keywords': [2, 'always'],
-    // require a space after certain keywords
-    'space-after-keywords': [2, 'always'],
+    // require a space before and after keywords
+    'keyword-spacing': 2,
     // require or disallow space before blocks
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis
@@ -111,8 +109,6 @@ module.exports = {
     'space-in-parens': [2, 'never'],
     // require spaces around operators
     'space-infix-ops': 2,
-    // require a space after return, throw, and case
-    'space-return-throw-case': 2,
     // Require or disallow spaces before/after unary operators
     'space-unary-ops': 0,
     // require or disallow a space immediately following the // or /* in a comment


### PR DESCRIPTION
- Replace removed rules in eslint@2.x with their counterparts (see [migration guide](http://eslint.org/docs/2.0.0/user-guide/migrating-to-2.0.0#removed-rules))
- Migrating ecmaOptions (see [migration guide](http://eslint.org/docs/2.0.0/user-guide/migrating-to-2.0.0\#language-options))
- Update eslint version in package.json to 2.0.0-beta

This is obviously breaking, so it might be for a future major version.