### PR TITLE
Sort static methods above constructor for React

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -334,8 +334,8 @@
 
   - Ordering for `class extends React.Component`:
 
-  1. `constructor`
   1. optional `static` methods
+  1. `constructor`
   1. `getChildContext`
   1. `componentWillMount`
   1. `componentDidMount`


### PR DESCRIPTION
I think it makes more sense to put static methods above the constructor
in classes. I would like to update the ESLint configuration to match
this, but it looks like the react/sort-comp rule does not support it
quite yet.

  https://github.com/yannickcr/eslint-plugin-react/issues/128