### PR TITLE
Small typo fix in 18.6 'bad'-example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1710,7 +1710,7 @@ Other Style Guides
         .updateCount();
 
     // bad
-    const leds = stage.selectAll('.led').data(data).enter().append('svg:svg').class('led', true)
+    const leds = stage.selectAll('.led').data(data).enter().append('svg:svg').classed('led', true)
         .attr('width', (radius + margin) * 2).append('svg:g')
         .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
         .call(tron.led);


### PR DESCRIPTION
Function call 'class()' to 'classed()'.