### PR TITLE
Enforce literal syntax for array creation

### DIFF
--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -64,7 +64,7 @@ module.exports = {
     // http://eslint.org/docs/rules/newline-per-chained-call
     'newline-per-chained-call': [0, { 'ignoreChainWithDepth': 3 }],
     // disallow use of the Array constructor
-    'no-array-constructor': 0,
+    'no-array-constructor': 2,
     // disallow use of the continue statement
     'no-continue': 0,
     // disallow comments inline after code


### PR DESCRIPTION
[As per your style guide](https://github.com/airbnb/javascript/blob/30c448d1df2c5a16bee4dd618ebdcf908b7475a3/README.md#4.1) you should create arrays using the literal syntax but the current value for the `no-array-constructor` rule is `0` which is disabled.

Changing this to `2` should show errors when arrays are created with constructors. 