### PR TITLE
remove statement on function expressions not being named

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Other Style Guides
 
   - [7.1](#7.1) <a name='7.1'></a> Use function declarations instead of function expressions. jscs: [`requireFunctionDeclarations`](http://jscs.info/rule/requireFunctionDeclarations)
 
-    > Why? Function declarations are named, so they're easier to identify in call stacks. Also, the whole body of a function declaration is hoisted, whereas only the reference of a function expression is hoisted. This rule makes it possible to always use [Arrow Functions](#arrow-functions) in place of function expressions.
+    > Why? The whole body of a function declaration is hoisted, whereas only the reference of a function expression is hoisted. This rule makes it possible to always use [Arrow Functions](#arrow-functions) in place of function expressions.
 
     ```javascript
     // bad


### PR DESCRIPTION
Confirmed that the function names _do_ appear in Chrome 49.0.2, Safari 9.0.3, Firefox 45.0b6, and Node 5.6.0, using the following code:

```javascript
var cb = function() {
  throw new Error("foo");
};
setTimeout(cb, 1000);
```

![screen shot 2016-03-01 at 12 03 53 pm](https://cloud.githubusercontent.com/assets/86842/13434909/b2091824-dfa5-11e5-886d-786fc549c4fc.png)
