### PR TITLE
Add space to function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ Other Style Guides
     };
 
     // good
-    function foo() {
+    function foo () {
     }
     ```
 


### PR DESCRIPTION
At 7.11 you say that function signatures should have spacing, yet there's no space in this function signature. This is confusing.