### PR TITLE
Improve guideline for image alt text

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "babel-tape-runner": "^1.3.1",
     "eslint": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^0.6.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.3.0",
     "react": "^0.14.8",
     "tape": "^4.5.1",

--- a/react/README.md
+++ b/react/README.md
@@ -216,20 +216,20 @@
     />
     ```
 
-  - Always include a non-empty `alt` prop on `<img>` tags. If `alt` is an empty string, the `<img>` must have `role="presentation"`. eslint: [`jsx-a11y/img-uses-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md)
+  - Always include an `alt` prop on `<img>` tags. If the image is presentational, `alt` can be an empty string or the `<img>` must have `role="presentation"`. eslint: [`jsx-a11y/img-uses-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md)
 
     ```jsx
     // bad
     <img src="hello.jpg" />
 
-    // bad
-    <img src="hello.jpg" alt="" />
-
     // good
     <img src="hello.jpg" alt="Me waving hello" />
 
     // good
-    <img src="hello.jpg" alt="" role="presentation" />
+    <img src="hello.jpg" alt="" />
+
+    // good
+    <img src="hello.jpg" role="presentation" />
     ```
 
   - Do not use words like "image", "photo", or "picture" in `<img>` `alt` props. eslint: [`jsx-a11y/redundant-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md)


### PR DESCRIPTION
After digging into this rule a little more with @evcohen, I believe that
it is okay for images to have an empty string for alt text. I expect the
next release of the linter rule to allow for this as well.

More context:

  https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/6