### PR TITLE
Link to eslint.org instead of github where possible

### DIFF
--- a/packages/eslint-config-airbnb/rules/es6.js
+++ b/packages/eslint-config-airbnb/rules/es6.js
@@ -18,7 +18,7 @@ module.exports = {
     // require parens in arrow function arguments
     'arrow-parens': 0,
     // require space before/after arrow function's arrow
-    // https://github.com/eslint/eslint/blob/master/docs/rules/arrow-spacing.md
+    // http://eslint.org/docs/rules/arrow-spacing
     'arrow-spacing': [2, { 'before': true, 'after': true }],
     // require trailing commas in multiline object literals
     'comma-dangle': [2, 'always-multiline'],
@@ -57,7 +57,7 @@ module.exports = {
     // http://eslint.org/docs/rules/no-useless-constructor
     'no-useless-constructor': 2,
     // require method and property shorthand syntax for object literals
-    // https://github.com/eslint/eslint/blob/master/docs/rules/object-shorthand.md
+    // http://eslint.org/docs/rules/object-shorthand
     'object-shorthand': [2, 'always'],
     // suggest using arrow functions as callbacks
     'prefer-arrow-callback': 2,

--- a/packages/eslint-config-airbnb/rules/style.js
+++ b/packages/eslint-config-airbnb/rules/style.js
@@ -24,7 +24,7 @@ module.exports = {
     // (variable names, property names etc.)
     'id-length': 0,
     // this option sets a specific tab width for your code
-    // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
+    // http://eslint.org/docs/rules/indent
     'indent': [2, 2, { 'SwitchCase': 1, 'VariableDeclarator': 1 }],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
@@ -46,7 +46,7 @@ module.exports = {
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     'linebreak-style': 0,
     // specify the maximum length of a line in your program
-    // https://github.com/eslint/eslint/blob/master/docs/rules/max-len.md
+    // http://eslint.org/docs/rules/max-len
     'max-len': [2, 100, 2, {
       'ignoreUrls': true,
       'ignoreComments': false
@@ -125,7 +125,7 @@ module.exports = {
     // require or disallow space before blocks
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis
-    // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
+    // http://eslint.org/docs/rules/space-before-function-paren
     'space-before-function-paren': [2, { 'anonymous': 'always', 'named': 'never' }],
     // require or disallow spaces inside parentheses
     'space-in-parens': [2, 'never'],


### PR DESCRIPTION
In most cases we link to documentation on the eslint.org site instead of
on GitHub. I found a couple of stragglers and decided to make things a
little more consistent.