### PR TITLE
'esnext' option has been deprecated.

### DIFF
--- a/linters/.jshintrc
+++ b/linters/.jshintrc
@@ -14,7 +14,7 @@
   "node": true,
 
   // Allow ES6.
-  "esnext": true,
+  "esversion": 6,
 
   /*
    * ENFORCING OPTIONS


### PR DESCRIPTION
http://jshint.com/docs/options/#esversion

**esnext**
Warning This option has been deprecated and will be removed in the next major release of JSHint. Use esversion: 6 instead.