### PR TITLE
Add arrow function returning object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,8 +809,6 @@ Other Style Guides
 
     > Why? Syntactic sugar. It reads well when multiple functions are chained together.
 
-    > Why not? If you plan on returning an object.
-
     ```javascript
     // bad
     [1, 2, 3].map(number => {
@@ -826,6 +824,11 @@ Other Style Guides
       const nextNumber = number + 1;
       return `A string containing the ${nextNumber}.`;
     });
+    
+    // good
+    [1, 2, 3].map((number, index) => ({
+      index: number
+    }));
     ```
 
   <a name="arrows--paren-wrap"></a><a name="8.3"></a>

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ Other Style Guides
       const nextNumber = number + 1;
       return `A string containing the ${nextNumber}.`;
     });
-    
+
     // good
     [1, 2, 3].map((number, index) => ({
       index: number

--- a/README.md
+++ b/README.md
@@ -2595,7 +2595,7 @@ Other Style Guides
 ## Testing
 
   <a name="testing--yup"></a><a name="28.1"></a>
-  - [28.1](#esting--yup) **Yup.**
+  - [28.1](#testing--yup) **Yup.**
 
     ```javascript
     function foo() {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -47,9 +47,8 @@
     "eslint": "^2.8.0",
     "eslint-find-rules": "^1.3.0",
     "eslint-config-airbnb-base": "^1.0.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-import": "^1.5.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-plugin-jsx-a11y": "^1.0.1",
     "eslint-plugin-react": "^5.0.1",
     "react": "*",
     "tape": "^4.5.1"
@@ -57,7 +56,7 @@
   "peerDependencies": {
     "eslint": "^2.8.0",
     "eslint-config-airbnb-base": "^1.0.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-plugin-jsx-a11y": "^1.0.1",
     "eslint-plugin-import": "^1.5.0",
     "eslint-plugin-react": "^5.0.1"
   }

--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -7,43 +7,81 @@ module.exports = {
     'jsx': true
   },
   'rules': {
+    // Require ARIA roles to be valid and non-abstract
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
+    'jsx-a11y/aria-role': 2,
+
+    // Enforce all aria-* props are valid.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
+    'jsx-a11y/aria-props': 0,
+
+    // Enforce ARIA state and property values are valid.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
+    'jsx-a11y/aria-proptypes': 0,
+
+    // Enforce that elements that do not support ARIA roles, states, and
+    // properties do not have those attributes.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
+    'jsx-a11y/aria-unsupported-elements': 0,
+
+    // disallow href "#"
+    // TODO: enable
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash.md
+    'jsx-a11y/href-no-hash': 0,
+
+    // Require <img> to have a non-empty `alt` prop, or role="presentation"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-has-alt.md
+    'jsx-a11y/img-has-alt': 2,
+
+    // Prevent img alt text from containing redundant words like "image", "picture", or "photo"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
+    'jsx-a11y/img-redundant-alt': 2,
+
+    // require that JSX labels use "htmlFor"
+    // TODO: enable
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
+    'jsx-a11y/label-has-for': 0,
+
+    // require that mouseover/out come with focus/blur, for keyboard-only users
+    // TODO: enable?
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
+    'jsx-a11y/mouse-events-have-key-events': 0,
+
     // Prevent use of `accessKey`
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
     'jsx-a11y/no-access-key': 2,
 
-    // Require <img> to have a non-empty `alt` prop, or role="presentation"
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md
-    'jsx-a11y/img-uses-alt': 2,
+    // require onBlur instead of onChange
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
+    'jsx-a11y/no-onchange': 0,
 
-    // Prevent img alt text from containing redundant words like "image", "picture", or "photo"
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/redundant-alt.md
-    'jsx-a11y/redundant-alt': 2,
-
-    // Require ARIA roles to be valid and non-abstract
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/valid-aria-role.md
-    'jsx-a11y/valid-aria-role': 2,
-
-    // require that JSX labels use "htmlFor"
-    // TODO: enable
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-uses-for.md
-    'jsx-a11y/label-uses-for': 0,
-
-    // require that mouseover/out come with focus/blur, for keyboard-only users
-    // TODO: enable?
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-map-to-key-events.md
-    'jsx-a11y/mouse-events-map-to-key-events': 0,
-
-    // disallow href "#"
-    // TODO: enable
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-hash-href.md
-    'jsx-a11y/no-hash-href': 0,
+    // Enforce that elements with onClick handlers must be focusable.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-focus.md
+    'jsx-a11y/onclick-has-focus': 0,
 
     // require things with onClick to have an aria role
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-uses-role.md
-    'jsx-a11y/onclick-uses-role': 0,
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-role.md
+    'jsx-a11y/onclick-has-role': 0,
 
-    // require onBlur instead of onChange
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/use-onblur-not-onchange.md
-    'jsx-a11y/use-onblur-not-onchange': 0,
+    // Enforce that elements with ARIA roles must have all required attributes
+    // for that role.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
+    'jsx-a11y/role-has-required-aria-props': 0,
+
+    // Enforce that elements with explicit or implicit roles defined contain
+    // only aria-* properties supported by that role.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
+    'jsx-a11y/role-supports-aria-props': 0,
+
+    // Enforce tabIndex value is not greater than zero.
+    // TODO: evaluate
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
+    'jsx-a11y/tabindex-no-positive': 0,
   },
 };

--- a/react/README.md
+++ b/react/README.md
@@ -216,7 +216,7 @@
     />
     ```
 
-  - Always include an `alt` prop on `<img>` tags. If the image is presentational, `alt` can be an empty string or the `<img>` must have `role="presentation"`. eslint: [`jsx-a11y/img-uses-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md)
+  - Always include an `alt` prop on `<img>` tags. If the image is presentational, `alt` can be an empty string or the `<img>` must have `role="presentation"`. eslint: [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-has-alt.md)
 
     ```jsx
     // bad
@@ -232,7 +232,7 @@
     <img src="hello.jpg" role="presentation" />
     ```
 
-  - Do not use words like "image", "photo", or "picture" in `<img>` `alt` props. eslint: [`jsx-a11y/redundant-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-uses-alt.md)
+  - Do not use words like "image", "photo", or "picture" in `<img>` `alt` props. eslint: [`jsx-a11y/img-redundant-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md)
 
   > Why? Screenreaders already announce `img` elements as images, so there is no need to include this information in the alt text.
 
@@ -244,7 +244,7 @@
     <img src="hello.jpg" alt="Me waving hello" />
     ```
 
-  - Use only valid, non-abstract [ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions). eslint: [`jsx-a11y/valid-aria-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/valid-aria-role.md)
+  - Use only valid, non-abstract [ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions). eslint: [`jsx-a11y/aria-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md)
 
     ```jsx
     // bad - not an ARIA role


### PR DESCRIPTION
Imo this looks better, than something like:

```javascript
[1, 2, 3].map((number, index) => {
  return {
    index: number
  }
});
```

What do you guys think? :) If you think that's bad style, maybe you should add this example with `//bad` comment?