### PR TITLE
Prepare to enable import/prefer-default-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,18 @@ Other Style Guides
     export { foo }
     ```
 
+  <a name="modules--prefer-default-export"></a>
+  - [10.6](#modules--prefer-default-export) In modules with a single export, prefer default export over named export.
+ eslint: [`import/prefer-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
+
+    ```javascript
+    // bad
+    export function foo() {}
+
+    // good
+    export default function foo() {}
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Iterators and Generators

--- a/packages/eslint-config-airbnb-base/rules/es6.js
+++ b/packages/eslint-config-airbnb-base/rules/es6.js
@@ -203,6 +203,11 @@ module.exports = {
       'newlines-between': 'never',
     }],
 
+    // Require modules with a single export to use a default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+    // TODO: enable
+    'import/prefer-default-export': 0,
+
     // Require a newline after the last import/require in a group
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
     // TODO: enable


### PR DESCRIPTION
This was recently added to eslint-plugin-export. It enforces that
modules that only have a single export use a default export instead of a
named export.

I believe that this will get our Travis build back to green.