### PR TITLE
Enable imports/imports-first rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,25 @@ Other Style Guides
     export default function foo() {}
     ```
 
+  <a name="modules--imports-first"></a>
+  - [10.7](#modules--imports-first) Put all `import`s above non-import statements.
+ eslint: [`import/imports-first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md)
+    > Why? Since `import`s are hoisted, keeping them all at the top prevents surprising behavior.
+
+    ```javascript
+    // bad
+    import foo from 'foo';
+    foo.init();
+
+    import bar from 'bar';
+
+    // good
+    import foo from 'foo';
+    import bar from 'bar';
+
+    foo.init();
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Iterators and Generators

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -86,8 +86,7 @@ module.exports = {
 
     // disallow non-import statements appearing before import statements
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md
-    // TODO: enable?
-    'import/imports-first': [0, 'absolute-first'],
+    'import/imports-first': [2, 'absolute-first'],
 
     // disallow duplicate imports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md


### PR DESCRIPTION
Since imports are hoisted, keeping them all at the top prevents
surprising behavior.