### PR TITLE
Fix deprecation warning of 'quotes' rule

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -209,7 +209,7 @@ module.exports = {
     'quote-props': [2, 'as-needed', { 'keywords': false, 'unnecessary': true, 'numbers': false }],
 
     // specify whether double or single quotes should be used
-    'quotes': [2, 'single', 'avoid-escape'],
+    'quotes': [2, 'single', {'avoid-escape': true, 'allowTemplateLiterals': true}],
 
     // do not require jsdoc
     // http://eslint.org/docs/rules/require-jsdoc


### PR DESCRIPTION
According to [eslint docs](http://eslint.org/docs/rules/quotes) the previous 'avoid-escape' option is deprecated, replaced by an object that includes 'allowTemplateLiterals'.