### PR TITLE
allow wildcard to make redux consts easily available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,19 +1088,6 @@ Other Style Guides
     export default es6;
     ```
 
-  <a name="modules--no-wildcard"></a><a name="10.2"></a>
-  - [10.2](#modules--no-wildcard) Do not use wildcard imports.
-
-    > Why? This makes sure you have a single default export.
-
-    ```javascript
-    // bad
-    import * as AirbnbStyleGuide from './AirbnbStyleGuide';
-
-    // good
-    import AirbnbStyleGuide from './AirbnbStyleGuide';
-    ```
-
   <a name="modules--no-export-from-import"></a><a name="10.3"></a>
   - [10.3](#modules--no-export-from-import) And do not export directly from an import.
 


### PR DESCRIPTION
A pattern seen in redux examples like https://github.com/reactjs/redux/blob/master/examples/todomvc/actions/index.js#L1is to use wildcard when importing a file that contains a bunch of exported constants.

This was originally added by @goatslacker in https://github.com/airbnb/javascript/pull/276 before redux was adapted.

cc @kesne @ljharb 