### PR TITLE
Fix invalid code snippet in 23.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2502,16 +2502,26 @@ Other Style Guides
 
     ```javascript
     // bad
-    dragon.age();
-
+    class Dragon {
+      get age() {
+        // ...
+      }
+    
+      set age(value) {
+        // ...
+      }
+    }
+    
     // good
-    dragon.getAge();
-
-    // bad
-    dragon.age(25);
-
-    // good
-    dragon.setAge(25);
+    class Dragon {
+      getAge() {
+        // ...
+      }
+    
+      setAge(value) {
+        // ...
+      }
+    }
     ```
 
   <a name="accessors--boolean-prefix"></a><a name="23.3"></a>


### PR DESCRIPTION
§[23.2](https://github.com/airbnb/javascript#accessors--no-getters-setters) proscribes the use of JS [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)/[setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get), but the code snippet shows something entirely different.

The existing snippet suggests against the following, which doesn't actually use `get`/`set`:
```js
dragon.age();
dragon.age(25);
```
With `get`/`set`, of course, the usage standpoint would be indistinguishable from a plain-old property:
```js
dragon.age;
dragon.age = 25;
```

As such, this PR replaces the existing snippet with an example from the `class` definition standpoint, which demonstrates what was actually intended here.