### PR TITLE
add missing return to bad example 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ Other Style Guides
     // bad
     [1, 2, 3].map(number => {
       const nextNumber = number + 1;
-      `A string containing the ${nextNumber}.`;
+      return `A string containing the ${nextNumber}.`;
     });
 
     // good


### PR DESCRIPTION
to make the bad/good examples do the same thing.

unless it was intentionally missing as part of being bad