### PR TITLE
Remove parens around single argument in React example

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -291,12 +291,12 @@
   )}
 
   // good
-  {todos.map((todo) =>
+  {todos.map(todo => (
     <Todo
       {...todo}
       key={todo.id}
     />
-  )}
+  ))}
   ```
 
 ## Parentheses


### PR DESCRIPTION
Parens around a single argument aren't in line with the [javascript guide](https://github.com/airbnb/javascript/blob/0814be638f22b01a8e49efd77094be24055a3d48/README.md#arrows--one-arg-parens):

> If your function takes a single argument and doesn’t use braces, omit the parentheses.