### PR TITLE
fix defaults for import/no-extraneous-dependencies

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -60,8 +60,8 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
     // TODO: enable
     'import/no-extraneous-dependencies': [0, {
-      devDependencies: false,
-      optionalDependencies: false,
+      devDependencies: true,
+      optionalDependencies: true,
     }],
 
     // Forbid mutable exports


### PR DESCRIPTION
These should both [default to true](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md). The rule is disabled so this doesn't really matter, but if you override it with `'import/no-extraneous-dependencies': 2`, now you'll get the expected defaults.