### PR TITLE
Minor typo: "coxcomb graph" v/s "coxcomb chart"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2204,7 +2204,7 @@ Other Style Guides
          firstName: 'Florence',
     -    lastName: 'Nightingale'
     +    lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb graph', 'modern nursing']
+    +    inventorOf: ['coxcomb chart', 'modern nursing']
     };
 
     // good - git diff with trailing comma


### PR DESCRIPTION
The "bad" and "good" diffs in section 19.2 ("Additional trailing comma ") had different text; making them the same to avoid confusion about what the difference is.