### PR TITLE
Update for ESLint 3.0.0

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -46,14 +46,14 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "babel-tape-runner": "^1.3.1",
-    "eslint": "^2.13.1",
+    "eslint": "^3.0.0",
     "eslint-find-rules": "^1.10.0",
     "eslint-plugin-import": "^1.8.1",
     "tape": "^4.5.1",
     "in-publish": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": "^2.13.1",
+    "eslint": "^2.13.1 || ^3.0.0",
     "eslint-plugin-import": "^1.8.1"
   }
 }

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -114,5 +114,9 @@ module.exports = {
     // Require modules with a single export to use a default export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
     'import/prefer-default-export': 2,
+
+    // Restrict which files can be imported in a given folder
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md
+    'import/no-restricted-paths': 0,
   },
 };

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "babel-tape-runner": "^1.3.1",
-    "eslint": "^2.10.2",
+    "eslint": "^3.0.0",
     "eslint-find-rules": "^1.9.2",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
@@ -59,7 +59,7 @@
     "in-publish": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": "^2.10.2",
+    "eslint": "^2.10.2 || ^3.0.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-react": "^5.1.1"

--- a/packages/eslint-config-airbnb/test/.eslintrc
+++ b/packages/eslint-config-airbnb/test/.eslintrc
@@ -3,7 +3,11 @@
     // disabled because I find it tedious to write tests while following this
     // rule
     "no-shadow": 0,
+
     // tests uses `t` for tape
-    "id-length": [2, {"min": 2, "properties": "never", "exceptions": ["t"]}]
+    "id-length": [2, {"min": 2, "properties": "never", "exceptions": ["t"]}],
+
+    // tests can import things in devDependencies
+    "import/no-extraneous-dependencies": [2, {"devDependencies": true}]
   }
 }

--- a/packages/eslint-config-airbnb/test/test-react-order.js
+++ b/packages/eslint-config-airbnb/test/test-react-order.js
@@ -8,8 +8,13 @@ const cli = new CLIEngine({
   useEslintrc: false,
   baseConfig: eslintrc,
 
-  // This rule fails when executing on text.
-  rules: { indent: 0 },
+  rules: {
+    // This rule fails when executing on text.
+    indent: 0,
+
+    // It is okay to import devDependencies in tests.
+    'import/no-extraneous-dependencies': [2, { devDependencies: true }],
+  },
 });
 
 function lint(text) {


### PR DESCRIPTION
ESLint 3.0.0 was recently released. I don't see any breaking changes
that affect our configuration, so it seems like we can support the
currently supported range in addition to 3.0.0+.

http://eslint.org/blog/2016/07/eslint-v3.0.0-released

I needed to fix a couple of minor things to get tests to pass. 