### PR TITLE
Prepare to switch to eslint-plugin-react 6

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -103,7 +103,7 @@ module.exports = {
 
     // Prevent React to be incorrectly marked as unused
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-    'react/jsx-uses-react': [2, { pragma: 'React' }],
+    'react/jsx-uses-react': 2,
 
     // Prevent variables used in JSX to be incorrectly marked as unused
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
@@ -115,15 +115,15 @@ module.exports = {
 
     // Prevent usage of deprecated methods
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
-    'react/no-deprecated': [1, { react: '0.14.0' }],
+    'react/no-deprecated': 1,
 
     // Prevent usage of setState in componentDidMount
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-mount-set-state': 2,
 
     // Prevent usage of setState in componentDidUpdate
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-did-update-set-state': [2, 'allow-in-func'],
+    'react/no-did-update-set-state': 2,
 
     // Prevent direct mutation of this.state
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
@@ -196,8 +196,8 @@ module.exports = {
     }],
 
     // Prevent missing parentheses around multilines JSX
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
-    'react/wrap-multilines': [2, {
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md
+    'react/jsx-wrap-multilines': [2, {
       declaration: true,
       assignment: true,
       return: true


### PR DESCRIPTION
This pull request is applicable to eslint-plugin-react@^6.0.0-rc.0. So I think it will be a good idea
to keep it until switching to that version and update it along with new breaking changes in react plugin.

"pragma" parameter from "jsx-uses-react" and "react" parameter from "no-deprecated" must be removed because they were deprecated in eslint-plugin-react since version 5.* and removed in 6.0.0-rc.0. Also it is already specified in the shared section (settings.react.pragma) as it should be, so nothing to fix there.

"allow-in-func" parameter must be removed from "no-did-mount-set-state" and "no-did-update-set-state" because since 6.0.0-rc.0 it is the default behavior and "allow-in-func" parameter was removed.

"wrap-multilnes" was deprecated and "jsx-wrap-multilines" must be used instead.