### PR TITLE
Add curlies around ref function body

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -337,7 +337,7 @@
 
     // good
     <Foo
-      ref={(ref) => this.myRef = ref}
+      ref={ref => { this.myRef = ref; }}
     />
     ```
 


### PR DESCRIPTION
The example we have here uses an implicit return, which is forbidden
when assigning. This triggers the no-return-assign rule.

Fixes #980