### PR TITLE
Proposal: [react][breaking] Only .js files should contain JSX.

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -223,9 +223,9 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
     'react/jsx-no-target-blank': 2,
 
-    // only .jsx files may have JSX
+    // only .js files may have JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
-    'react/jsx-filename-extension': [2, { extensions: ['.jsx'] }],
+    'react/jsx-filename-extension': [2, { extensions: ['.js'] }],
 
     // prevent accidental JS comments from being injected into JSX as text
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md


### PR DESCRIPTION
Opening this for comments and discussion. I would like to suggest only using JSX inside of .js files. Here is a short rationale for doing so:

* Most modern projects are transpiling code with tools that support JSX. In this case it makes sense to keep everything together inside a single .js file.

* Cleaner import and require statements. For .js files I can import the file by its name, instead of having to include the .jsx file. E.g., `require('./MyComponent');` vs `require('./MyComponent.jsx');`

* While JSX is not ecmascript, it is transpiled JS, in the same vein that flow and stage 0 babel transforms are. There's no reason to differentiate.

Additional discussion: https://github.com/facebook/react/issues/3582#issuecomment-89411479