### PR TITLE
[guide] Add eslint rules to `spacing in a function signature` topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Other Style Guides
     ```
 
   <a name="functions--signature-spacing"></a><a name="7.11"></a>
-  - [7.11](#functions--signature-spacing) Spacing in a function signature.
+  - [7.11](#functions--signature-spacing) Spacing in a function signature. eslint: [`space-before-function-paren`](http://eslint.org/docs/rules/space-before-function-paren) [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks)
 
     > Why? Consistency is good, and you shouldn’t have to add or remove a space when adding or removing a name.
 


### PR DESCRIPTION
I believe these two rules are able to cover what the topic 7.11 is talking about. The space-before-function-paren can enforce anonymous functions to have a space before its parentheses, and space-before-block can enforce the opening curly brace to have a space before it.