### PR TITLE
Add template literal "bad" example to single quotes guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ Other Style Guides
     // bad
     const name = "Capt. Janeway";
 
+    // bad - template literals should contain interpolation or newlines
+    const name = `Capt. Janeway`;
+
     // good
     const name = 'Capt. Janeway';
     ```


### PR DESCRIPTION
There has been some confusion around whether we should use single quotes
or template literals. To help avoid this confusion, I am adding a "bad"
example to the single quotes guideline. This rule is already enforced by
the quotes linter rule.

Generally, we want code to clearly express developer intention. Using
template literals communicates that you intend to use some of the
features that template literals offer (e.g. interpolation).

Fixes #992