### PR TITLE
[guide] Add a why quote in the 7.7 topic and remove comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,12 +636,11 @@ Other Style Guides
   <a name="es6-default-parameters"></a><a name="7.7"></a>
   - [7.7](#es6-default-parameters) Use default parameter syntax rather than mutating function arguments.
 
+    > Why? Consider `opts = opts || {}` to apply a default value to the opts argument. This pattern is verbose, and if opts is falsy it'll be set to an object which may be what you want, but it can introduce subtle bugs.
+
     ```javascript
     // really bad
     function handleThings(opts) {
-      // No! We shouldn't mutate function arguments.
-      // Double bad: if opts is falsy it'll be set to an object which may
-      // be what you want but it can introduce subtle bugs.
       opts = opts || {};
       // ...
     }


### PR DESCRIPTION
Related to #990 
I removed the comment "No! We shouldn't mutate function arguments.", because it doesn't add any new information and added a "Why?" quote.
