### PR TITLE
[guide] Add ESlint rules to 'always use const' and 'decriptive variable names' topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,7 @@ Other Style Guides
 ## Variables
 
   <a name="variables--const"></a><a name="13.1"></a>
-  - [13.1](#variables--const) Always use `const` to declare variables. Not doing so will result in global variables. We want to avoid polluting the global namespace. Captain Planet warned us of that.
+  - [13.1](#variables--const) Always use `const` to declare variables. Not doing so will result in global variables. We want to avoid polluting the global namespace. Captain Planet warned us of that. eslint: [`no-undef`](http://eslint.org/docs/rules/no-undef) [`prefer-const`](http://eslint.org/docs/rules/prefer-const)
 
     ```javascript
     // bad
@@ -2327,7 +2327,7 @@ Other Style Guides
 ## Naming Conventions
 
   <a name="naming--descriptive"></a><a name="22.1"></a>
-  - [22.1](#naming--descriptive) Avoid single letter names. Be descriptive with your naming.
+  - [22.1](#naming--descriptive) Avoid single letter names. Be descriptive with your naming. eslint: [`id-length`](http://eslint.org/docs/rules/id-length)
 
     ```javascript
     // bad


### PR DESCRIPTION
I believe these ESlint rules are able to cover what the topics 13.1 and 22.1 are talking about.

For 13.1:
`no-undef` will prevent global variables.
`prefer-const` will recommend `const` when possible.

For 22.1
`id-length` lets you define a minimum size for the variable names.