### PR TITLE
[eslint config] [base] [breaking] Add no-plusplus in base errors.js and desc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,35 @@ Other Style Guides
     }
     ```
 
+    - [13.5](#variables--unary-increment-decrement) Avoid using unary increments and decrements (++, --). eslint [`no-plusplus`](http://eslint.org/docs/rules/no-plusplus)
+
+      > Why? Per the eslint documentation, unary increment and decrement statements are subject to automatic semicolon insertion and can cause silent errors with incrementing or decrementing values within an application. It is also more expressive to mutate your values with statements like `num += 1` instead of `num ++`. Disallowing unary increment and decrement statements also prevents you from pre-incrementing/pre-decrementing values unintentionally which can also cause unexpected behavior in your programs.
+
+      ```javascript
+        // bad
+
+        let array = [1, 2, 3];
+        let num = 1;
+        let increment = num ++;
+        let decrement = -- num;
+
+        for(let i = 0; i < array.length; i++){
+          let value = array[i];
+          ++value;
+        }
+
+        // good
+
+        let array = [1, 2, 3];
+        let num = 1;
+        let increment = num += 1;
+        let decrement = num -= 1;
+
+        array.forEach((value) => {
+          value += 1;
+        });
+      ```
+
 **[⬆ back to top](#table-of-contents)**
 
 

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -180,7 +180,8 @@ module.exports = {
     'no-new-object': 'error',
 
     // disallow use of unary operators, ++ and --
-    'no-plusplus': 'off',
+    // http://eslint.org/docs/rules/no-plusplus
+    'no-plusplus': 2,
 
     // disallow certain syntax forms
     // http://eslint.org/docs/rules/no-restricted-syntax


### PR DESCRIPTION
@ljharb  Added `no-plusplus: 'error'` to eslint-config-airbnb-base/errors.js in order to disallow unary increment and decrement statements.  In addition, added description under Variables in the main README. 

This PR references https://github.com/airbnb/javascript/issues/540.