### PR TITLE
Remove misleading reference to one-var eslint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,7 +1418,7 @@ Other Style Guides
     }
     ```
   <a name="variables--no-chain-assignment"></a><a name="13.5"></a>
-  - [13.5](#variables--no-chain-assignment) Don't chain variable assignments. eslint: [`one-var`](http://eslint.org/docs/rules/one-var.html)
+  - [13.5](#variables--no-chain-assignment) Don't chain variable assignments.
 
     > Why? Chaining variable assignments creates implicit global variables.
 


### PR DESCRIPTION
This eslint rule does not enforce this style guide rule. I believe that
referencing it here will cause people to believe that this is enforced
via linting when it is not. As far as I know, there is no rule that
currently enforces this, but it would be nice to add one.