### PR TITLE
Fix issue with eslint-config-airbnb README.md file formatting

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -27,6 +27,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   ```
 
 2. Add `"extends": "airbnb"` to your .eslintrc
+
 ### eslint-config-airbnb/base
 
 This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).


### PR DESCRIPTION
Just a small fix for `eslint-config-airbnb/base` subheading.

**Before:**

<img width="956" alt="airbnb" src="https://cloud.githubusercontent.com/assets/1968098/17788074/92eb04f0-6594-11e6-94be-7ccc186837b0.png">

---

**After:**

<img width="955" alt="airbnb-fixed" src="https://cloud.githubusercontent.com/assets/1968098/17788081/9a5c83b2-6594-11e6-8324-8e0dd26a34fb.png">
