### PR TITLE
Explain why not to prefix methods with underscores

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -450,6 +450,7 @@
     ```
 
   - Do not use underscore prefix for internal methods of a React component.
+  > Why? Underscore prefixes are sometimes used as a convention in other languages to denote privacy. But, unlike those languages, there is no native support for privacy in JavaScript, everything is public. Regardless of your intentions, adding underscore prefixes to your properties does not actually make them private, and any property (underscore-prefixed or not) should be treated as being public. See issues #1024, and #490 for a more in-depth discussion.
 
     ```jsx
     // bad


### PR DESCRIPTION
Fixes issue #1024 