### PR TITLE
Fix a typo in commas section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2221,6 +2221,7 @@ Other Style Guides
   - [19.2](#commas--dangling) Additional trailing comma: **Yup.** eslint: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html) jscs: [`requireTrailingComma`](http://jscs.info/rule/requireTrailingComma)
 
     > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](es5/README.md#commas) in legacy browsers.
+    
     ```javascript
     // bad - git diff without trailing comma
     const hero = {


### PR DESCRIPTION
Example code block following blockquote(line 2223) was broken as a line break was missing. So I just added single blank line.