### PR TITLE
Document react/require-render-return as a fully fledged rule

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -472,7 +472,7 @@
     }
     ```
 
-  - Be sure to return a value in your `render` methods. eslint: [`require-render-return`](https://github.com/yannickcr/eslint-plugin-react/pull/502)
+  - Be sure to return a value in your `render` methods. eslint: [`react/require-render-return`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)
 
     ```jsx
     // bad


### PR DESCRIPTION
Now that the pull request has been merged, we can reference the actual rule.