### PR TITLE
Update shell commands in readmes

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -15,8 +15,8 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
 1. Ensure packages are installed with correct version numbers by running:
   ```sh
   (
-    export PKG=eslint-config-airbnb-base;
-    npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
+    PKG=eslint-config-airbnb-base
+    npm info "$PKG" peerDependencies --json | sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
   )
   ```
 
@@ -35,8 +35,8 @@ Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
 1. Ensure packages are installed with correct version numbers by running:
   ```sh
   (
-    export PKG=eslint-config-airbnb-base;
-    npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
+    PKG=eslint-config-airbnb-base
+    npm info "$PKG" peerDependencies --json | sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
   )
   ```
 

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -15,8 +15,8 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
 1. Ensure packages are installed with correct version numbers by running:
   ```sh
   (
-    export PKG=eslint-config-airbnb;
-    npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
+    PKG=eslint-config-airbnb
+    npm info "$PKG" peerDependencies --json | sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
   )
   ```
 


### PR DESCRIPTION
• Remove exports when variable is not used by subprocesses.

• Remove command keyword where no conflicting shell functions exist.

• Remove needless trailing semicolons for consistency with second
  statement.