### PR TITLE
Fix header link to Classes & Constructors from ECMAScript 6+ Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2754,7 +2754,7 @@ Other Style Guides
   - [27.1](#es6-styles) This is a collection of links to the various ES6 features.
 
 1. [Arrow Functions](#arrow-functions)
-1. [Classes](#constructors)
+1. [Classes](#classes--constructors)
 1. [Object Shorthand](#es6-object-shorthand)
 1. [Object Concise](#es6-object-concise)
 1. [Object Computed Properties](#es6-computed-properties)


### PR DESCRIPTION
This is a small fix to a make a link to the Classes & Constructors header work from the ECMAScript 6+ Styles section.