### PR TITLE
Add JavaScript Air to list of Podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2893,6 +2893,7 @@ Other Style Guides
 
 **Podcasts**
 
+  - [JavaScript Air](https://javascriptair.com/)
   - [JavaScript Jabber](https://devchat.tv/js-jabber/)
 
 


### PR DESCRIPTION
It probably wouldn't be a bad idea for us to make a full pass on
updating the resources section, but I noticed the podcasts portion was
missing JS Air.

cc @kentcdodds