### PR TITLE
update 8.3 to fix conflict with 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,15 +849,18 @@ Other Style Guides
 
     ```js
     // bad
-    [1, 2, 3].map(number => 'As time went by, the string containing the ' +
-      `${number} became much longer. So we needed to break it over multiple ` +
-      'lines.'
+    ['get', 'post', 'put'].map(number => Object.prototype.hasOwnProperty.call(
+        httpMagicObjectWithAVeryLongName,
+        httpMethod
+      )
     );
 
     // good
-    [1, 2, 3].map(number => (
-      `As time went by, the string containing the ${number} became much ` +
-      'longer. So we needed to break it over multiple lines.'
+    ['get', 'post', 'put'].map(number => (
+      Object.prototype.hasOwnProperty.call(
+        httpMagicObjectWithAVeryLongName,
+        httpMethod
+      )
     ));
     ```
 


### PR DESCRIPTION
6.2 goes against 8.3 - string across multiple lines.

Can't find a better example of a very long return statement