### PR TITLE
Set 'allowTemplateLiterals' to true on 'quotes' rule.

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -276,7 +276,7 @@ module.exports = {
     'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
 
     // specify whether double or single quotes should be used
-    quotes: ['error', 'single', { avoidEscape: true }],
+    quotes: ['error', 'single', { avoidEscape: true , allowTemplateLiterals: true }],
 
     // do not require jsdoc
     // http://eslint.org/docs/rules/require-jsdoc


### PR DESCRIPTION
Added allowTemplateLiterals option to quotes rule. This prevents a quotes error on a template string.

Current Behavior:
```
const foo = 'foo';
const foobar = foo + 'bar';
// Error Thrown: prefer-template
const foobar_template = `@{foo}bar`;
// Error Thrown: quotes (strings must be in single quotes)
```

New Behavior:
```
const foo = 'foo';
const foobar = foo + 'bar';
// Error Thrown: prefer-template
const foobar_template = `@{foo}bar`;
// No error thrown
```