### PR TITLE
class-methods-use-this: exempt React getChildContext

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -23,6 +23,7 @@ module.exports = {
         'render',
         'getInitialState',
         'getDefaultProps',
+        'getChildContext',
         'componentWillMount',
         'componentDidMount',
         'componentWillReceiveProps',


### PR DESCRIPTION
Added `getChildContext` to the exceptions list for `class-methods-use-this`