### PR TITLE
Upgrade to import plugin v2

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -49,14 +49,14 @@
     "babel-tape-runner": "^2.0.1",
     "eslint": "^3.7.1",
     "eslint-find-rules": "^1.14.0",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.0.1",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.1",
     "tape": "^4.6.2"
   },
   "peerDependencies": {
     "eslint": "^3.7.1",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint-plugin-import": "^2.0.1"
   },
   "engines": {
     "node": ">= 4"

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -33,7 +33,7 @@ module.exports = {
 
     // ensure imports point to files/modules that can be resolved
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-    'import/no-unresolved': ['error', { commonjs: true }],
+    'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
 
     // ensure named imports coupled with named exports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it
@@ -93,8 +93,13 @@ module.exports = {
     // Style guide:
 
     // disallow non-import statements appearing before import statements
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
+    'import/first': ['error', 'absolute-first'],
+
+    // disallow non-import statements appearing before import statements
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md
-    'import/imports-first': ['error', 'absolute-first'],
+    // deprecated: use `import/first`
+    'import/imports-first': 'off',
 
     // disallow duplicate imports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
@@ -149,5 +154,18 @@ module.exports = {
     'import/no-internal-modules': ['off', {
       allow: [],
     }],
+
+    // Warn if a module could be mistakenly parsed as a script by a consumer leveraging Unambiguous
+    // JavaScript Grammar
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/unambiguous.md
+    'import/unambiguous': 'off',
+
+    // Forbid Webpack loader syntax in imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+    'import/no-webpack-loader-syntax': 'off',
+
+    // Prevent unassigned imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md
+    'import/no-unassigned-import': 'off',
   },
 };


### PR DESCRIPTION
[Breaking changes](https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md#200---2016-09-30) seems to just involve changing defaults, which is already defined in this project, so no difference.
Still a breaking change for this module because of the changed peer I suppose, but rules wise, it's not.