### PR TITLE
Update section 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ Other Style Guides
     });
 
     // good
-    [1, 2, 3].map((x) => {
+    [1, 2, 3].map(x => {
       const y = x + 1;
       return x * y;
     });


### PR DESCRIPTION
The "good" example on line 832 breaks the one arg parens rule for the style guide.