### PR TITLE
Fix minor naming typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,7 +1148,7 @@ Other Style Guides
     ```javascript
     // bad
     // filename es6.js
-    export { es6 as default } from './airbnbStyleGuide';
+    export { es6 as default } from './AirbnbStyleGuide';
 
     // good
     // filename es6.js


### PR DESCRIPTION
Changed `./airbnbStyleGuide` to `./AirbnbStyleGuide` to standardise with the rest of the examples.

Just something I chanced upon while reading through 😄 