### PR TITLE
Enable `import/no-webpack-loader-syntax` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,21 @@ Other Style Guides
     } from 'path';
     ```
 
+  <a name="modules--no-webpack-loader-syntax"></a>
+  - [10.9](#modules--no-webpack-loader-syntax) Disallow Webpack loader syntax in module import statements.
+ eslint: [`import/no-webpack-loader-syntax`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)
+    > Why? Since using Webpack syntax in the imports couples the code to a module bundler. Prefer using the loader syntax in `webpack.config.js`.
+
+    ```javascript
+    // bad
+    import fooSass from 'css!sass!foo.scss';
+    import barCss from 'style!css!bar.css';
+
+    // good
+    import fooSass from 'foo.scss';
+    import barCss from 'bar.css';
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Iterators and Generators

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -162,7 +162,7 @@ module.exports = {
 
     // Forbid Webpack loader syntax in imports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
-    'import/no-webpack-loader-syntax': 'off',
+    'import/no-webpack-loader-syntax': 'error',
 
     // Prevent unassigned imports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md


### PR DESCRIPTION
Like mentioned in the imports v2 PR.

IDK if it's a good enough description. Link to webpack docs on loaders?

Could probably have done with an issue first, but this just took 5 minutes, so...