### PR TITLE
Update `import/no-extraneous-dependencies` to alow test files

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -67,7 +67,7 @@ module.exports = {
     // Forbid the use of extraneous packages
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
     'import/no-extraneous-dependencies': ['error', {
-      devDependencies: false,
+      devDependencies: ['**/test.js', '**/spec.js', '**/*.test.js', '**/*.spec.js'],
       optionalDependencies: false,
     }],
 


### PR DESCRIPTION
It now allows devDependencies in all files called `test.js`, `spec.js`,
`*.test.js` or `*.spec.js`