### PR TITLE
Update eslint to 3.8.0

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "babel-preset-airbnb": "^2.1.1",
     "babel-tape-runner": "^2.0.1",
-    "eslint": "^3.7.1",
+    "eslint": "^3.8.0",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^2.0.1",
     "in-publish": "^2.0.0",
@@ -55,7 +55,7 @@
     "tape": "^4.6.2"
   },
   "peerDependencies": {
-    "eslint": "^3.7.1",
+    "eslint": "^3.8.0",
     "eslint-plugin-import": "^2.0.1"
   },
   "engines": {

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -250,7 +250,7 @@ module.exports = {
 
     // require immediate function invocation to be wrapped in parentheses
     // http://eslint.org/docs/rules/wrap-iife.html
-    'wrap-iife': ['error', 'outside'],
+    'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
 
     // require or disallow Yoda conditions
     yoda: 'error'

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -32,7 +32,13 @@ module.exports = {
     // http://eslint.org/docs/rules/func-call-spacing
     'func-call-spacing': ['error', 'never'],
 
+    // requires function names to match the name of the variable or property to which they are
+    // assigned
+    // http://eslint.org/docs/rules/func-name-matching
+    'func-name-matching': ['off', { includeCommonJSModuleExports: false }],
+
     // require function expressions to have a name
+    // http://eslint.org/docs/rules/func-names
     'func-names': 'warn',
 
     // enforces use of function declarations or expressions
@@ -303,7 +309,11 @@ module.exports = {
 
     // require or disallow space before function opening parenthesis
     // http://eslint.org/docs/rules/space-before-function-paren
-    'space-before-function-paren': ['error', { anonymous: 'always', named: 'never' }],
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
 
     // require or disallow spaces inside parentheses
     'space-in-parens': ['error', 'never'],

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "babel-preset-airbnb": "^2.1.1",
     "babel-tape-runner": "^2.0.1",
-    "eslint": "^3.7.1",
+    "eslint": "^3.8.0",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
@@ -61,7 +61,7 @@
     "tape": "^4.6.2"
   },
   "peerDependencies": {
-    "eslint": "^3.7.1",
+    "eslint": "^3.8.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-react": "^6.4.1"


### PR DESCRIPTION
New rule called `func-name-matching` added

Based on https://github.com/airbnb/javascript#functions, where you have

```js
// good
const foo = function bar() {
};
```

`off` seems correct here.

I also added a missing link