### PR TITLE
[guide] Fix inconsistency in function expression rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Other Style Guides
   <a name="functions--declarations"></a><a name="7.1"></a>
   - [7.1](#functions--declarations) Use named function expressions instead of function declarations. eslint: [`func-style`](http://eslint.org/docs/rules/func-style) jscs: [`requireFunctionDeclarations`](http://jscs.info/rule/requireFunctionDeclarations)
 
-    > Why? Function declarations are hoisted, which means that it’s easy - too easy - to reference the function before it is defined in the file. This harms readability and maintainability. If you find that a function’s definition is large or complex enough that it is interfering with understanding the rest of the file, then perhaps it’s time to extract it to its own module! Don’t forget to name the expression - anonymous functions can make it harder to locate the problem in an Error's call stack.
+    > Why? Function declarations are hoisted, which means that it’s easy - too easy - to reference the function before it is defined in the file. This harms readability and maintainability. If you find that a function’s definition is large or complex enough that it is interfering with understanding the rest of the file, then perhaps it’s time to extract it to its own module! Don’t forget to name the expression - anonymous functions can make it harder to locate the problem in an Error's call stack. ([Discussion](https://github.com/airbnb/javascript/issues/794))
 
     ```javascript
     // bad


### PR DESCRIPTION
The link to a discussion around anonymous expressions and whether they're easy to find in ES6 ([diff](https://github.com/airbnb/javascript/pull/1036/commits/1541503fd47626e2d4b03ff01bca76940081edeb)) was lost in the PR #1008 , and introduced a slight inconsistency in the "good" example where the function expression is different from the named function, which I'm guessing was not intentional.
