### PR TITLE
Fix broken rule reference link `import/first`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,7 @@ Other Style Guides
 
   <a name="modules--imports-first"></a>
   - [10.7](#modules--imports-first) Put all `import`s above non-import statements.
- eslint: [`import/imports-first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md)
+ eslint: [`import/first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)
     > Why? Since `import`s are hoisted, keeping them all at the top prevents surprising behavior.
 
     ```javascript


### PR DESCRIPTION
`import/imports-first` is renamed to `import/first`.

Also old link has been deleted, got 404 when navigate.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbnb/javascript/1143)

<!-- Reviewable:end -->
