### PR TITLE
Add reference for `Object.assign`

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Other Style Guides
   ```
 
   <a name="objects--rest-spread"></a>
-  - [3.8](#objects--rest-spread) Prefer the object spread operator over `Object.assign` to shallow-copy objects. Use the object rest operator to get a new object with certain properties omitted.
+  - [3.8](#objects--rest-spread) Prefer the object spread operator over [`Object.assign`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) to shallow-copy objects. Use the object rest operator to get a new object with certain properties omitted.
 
   ```javascript
   // very bad


### PR DESCRIPTION
We have external references for `Array#push` and `Array.from`, it'd be great if we have one for `Object.assign` too.