### PR TITLE
Allows unary operators ++ and -- in the afterthought (final expression) of a for loop

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -212,7 +212,7 @@ module.exports = {
 
     // disallow use of unary operators, ++ and --
     // http://eslint.org/docs/rules/no-plusplus
-    'no-plusplus': 'error',
+    'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
 
     // disallow certain syntax forms
     // http://eslint.org/docs/rules/no-restricted-syntax


### PR DESCRIPTION
RE: [13.6 Avoid using unary increments and decrements](https://github.com/airbnb/javascript#variables--unary-increment-decrement)
Let's allow to use canonical for-loop syntax with `i++`.
```js
for (i = 0; i < l; i--) {
    return;
}

function* recursion(/* ... */) {
  for (let i = 0; i < length; i++) {
    yield* recursion(/* ... */);
  }
}
```
Using addition assignment here looks strange to say the least.
ESLint [no-plusplus](http://eslint.org/docs/rules/no-plusplus) rule has a [special case](http://eslint.org/docs/rules/no-plusplus#allowforloopafterthoughts) for allowing unary operators in the for-loops.