### PR TITLE
Use num++ instead of num ++

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,15 +1547,15 @@ Other Style Guides
   <a name="variables--unary-increment-decrement"></a><a name="13.6"></a>
   - [13.6](#variables--unary-increment-decrement) Avoid using unary increments and decrements (++, --). eslint [`no-plusplus`](http://eslint.org/docs/rules/no-plusplus)
 
-    > Why? Per the eslint documentation, unary increment and decrement statements are subject to automatic semicolon insertion and can cause silent errors with incrementing or decrementing values within an application. It is also more expressive to mutate your values with statements like `num += 1` instead of `num ++`. Disallowing unary increment and decrement statements also prevents you from pre-incrementing/pre-decrementing values unintentionally which can also cause unexpected behavior in your programs.
+    > Why? Per the eslint documentation, unary increment and decrement statements are subject to automatic semicolon insertion and can cause silent errors with incrementing or decrementing values within an application. It is also more expressive to mutate your values with statements like `num += 1` instead of `num++` or `num ++`. Disallowing unary increment and decrement statements also prevents you from pre-incrementing/pre-decrementing values unintentionally which can also cause unexpected behavior in your programs.
 
     ```javascript
       // bad
 
       let array = [1, 2, 3];
       let num = 1;
-      num ++;
-      -- num;
+      num++;
+      --num;
 
       let sum = 0;
       let truthyCount = 0;


### PR DESCRIPTION
I've never seen anyone do `num ++`, people don't do that. So I changed it to `num++` so it is more realistic and reflects actual common practices.