### PR TITLE
[guide] Separate 19.2 code blocks into diff + javascript sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2393,7 +2393,7 @@ Other Style Guides
 
     > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](https://github.com/airbnb/javascript/blob/es5-deprecated/es5/README.md#commas) in legacy browsers.
 
-    ```javascript
+    ```diff
     // bad - git diff without trailing comma
     const hero = {
          firstName: 'Florence',
@@ -2408,7 +2408,9 @@ Other Style Guides
          lastName: 'Nightingale',
     +    inventorOf: ['coxcomb chart', 'modern nursing'],
     };
+    ```
 
+    ```javascript
     // bad
     const hero = {
       firstName: 'Dana',


### PR DESCRIPTION
Section 19.2 had a huge code block with both a git diff and javascript code. This change splits the code block into two parts, one with diff highlighting and one with javascript highlighting.