### PR TITLE
Add information about NaN comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,6 +1695,7 @@ Other Style Guides
     + **Booleans** evaluate to **the value of the boolean**
     + **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
     + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
+    + **NaN** comparisons always evaluate to false, even **NaN === NaN**
 
     ```javascript
     if ([0] && []) {


### PR DESCRIPTION
You mention NaN evaluates to false but don't explicitly mention that any comparison to NaN evalutes to false, including NaN === NaN.  Added a note about this at the bottom of that section.  