### PR TITLE
Remove wrong example for 11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,11 +1313,6 @@ Other Style Guides
     sum === 15;
 
     // good
-    let sum = 0;
-    numbers.forEach(num => sum += num);
-    sum === 15;
-
-    // best (use the functional force)
     const sum = numbers.reduce((total, num) => total + num, 0);
     sum === 15;
     ```


### PR DESCRIPTION
Removed example had nothing in common with the "Why" section and was too much like "bad" one.