### PR TITLE
Remove "no-duplicate-imports" rule

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/es6.js
+++ b/packages/eslint-config-airbnb-base/rules/es6.js
@@ -53,10 +53,6 @@ module.exports = {
     // http://eslint.org/docs/rules/no-dupe-class-members
     'no-dupe-class-members': 'error',
 
-    // disallow importing from the same path more than once
-    // http://eslint.org/docs/rules/no-duplicate-imports
-    'no-duplicate-imports': 'error',
-
     // disallow symbol constructor
     // http://eslint.org/docs/rules/no-new-symbol
     'no-new-symbol': 'error',


### PR DESCRIPTION
As far as I can tell, `no-duplicate-imports` is _replaced_ by `[import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)`.

`no-duplicate-imports` breaks with Flow types; `import/no-duplicates` works.

e.g. this should work, but it currently breaks with `no-duplicate-imports` enabled.
```js
import { foo } from './bar';
import type { Baz } from './bar';
```

Reference:
https://github.com/babel/eslint-plugin-babel/issues/59