### PR TITLE
Avoid i++ in array spreads example

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Other Style Guides
     const itemsCopy = [];
     let i;
 
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len; i += 1) {
       itemsCopy[i] = items[i];
     }
 
@@ -565,7 +565,7 @@ Other Style Guides
 
     // good
     const foo = '\'this\' is "quoted"';
-    const foo = `my name is '${name}'`;		
+    const foo = `my name is '${name}'`;
     ```
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
This style guide recommends using `i += 1` over `i++`. Even though this
appears in a "bad" example, the example will be clearest if it is "bad"
in fewer ways.

I removed some trailing whitespace for free.