### PR TITLE
[guide][react] Add missing parenthesis in «Refs» recommendation

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -378,7 +378,7 @@
 
     // good
     <Foo
-      ref={ref => { this.myRef = ref; }}
+      ref={(ref) => { this.myRef = ref; }}
     />
     ```
 


### PR DESCRIPTION
As is, actual «good» usage example fires the [arrow-parens rule](https://github.com/soulchainer/javascript/blob/master/packages/eslint-config-airbnb-base/rules/es6.js#L23).
Parenthesis are needed to follow the current style guide.