### PR TITLE
Add gulpfile.*.js to import/no-extraneous-dependencies ignore list

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -80,6 +80,7 @@ module.exports = {
         '**/webpack.config.*.js', // webpack config
         '**/rollup.config.js', // rollup config
         '**/gulpfile.js', // gulp config
+        '**/gulpfile.*.js', // gulp config
         '**/Gruntfile', // grunt config
       ],
       optionalDependencies: false,


### PR DESCRIPTION
Otherwise gulp configs that are using babel or other preprocessors with filenames like `gulpfile.babel.js` won't be matched by the ignore list for importing extraneous dependencies.