### PR TITLE
Added flowtype linting support through the use of a new package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,18 @@
   "version": "2.0.0",
   "description": "A mostly reasonable approach to JavaScript.",
   "scripts": {
-    "preinstall": "npm run install:config && npm run install:config:base",
+    "preinstall": "npm run install:config && npm run install:config:base && npm run install:config:next",
     "install:config": "cd packages/eslint-config-airbnb && npm prune && npm install",
     "install:config:base": "cd packages/eslint-config-airbnb-base && npm prune && npm install",
-    "test": "npm run --silent test:config && npm run --silent test:config:base",
+    "install:config:next": "cd packages/eslint-config-airbnb-next && npm prune && npm install",
+    "test": "npm run --silent test:config && npm run --silent test:config:base && npm run --silent test:config:next",
     "test:config": "cd packages/eslint-config-airbnb; npm test",
     "test:config:base": "cd packages/eslint-config-airbnb-base; npm test",
-    "travis": "npm run --silent travis:config && npm run --silent travis:config:base",
+    "test:config:next": "cd packages/eslint-config-airbnb-next; npm test",
+    "travis": "npm run --silent travis:config && npm run --silent travis:config:base && npm run --silent travis:config:next",
     "travis:config": "cd packages/eslint-config-airbnb; npm run travis",
-    "travis:config:base": "cd packages/eslint-config-airbnb-base; npm run travis"
+    "travis:config:base": "cd packages/eslint-config-airbnb-base; npm run travis",
+    "travis:config:next": "cd packages/eslint-config-airbnb-next; npm run travis"
   },
   "repository": {
     "type": "git",
@@ -24,7 +27,8 @@
     "es6",
     "es2015",
     "react",
-    "jsx"
+    "jsx",
+    "flowtype"
   ],
   "author": "Harrison Shoff <hi@hshoff.com> (https://twitter.com/hshoff)",
   "license": "MIT",

--- a/packages/eslint-config-airbnb-next/.babelrc
+++ b/packages/eslint-config-airbnb-next/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["airbnb"]
+}

--- a/packages/eslint-config-airbnb-next/.editorconfig
+++ b/packages/eslint-config-airbnb-next/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = null

--- a/packages/eslint-config-airbnb-next/.eslintrc
+++ b/packages/eslint-config-airbnb-next/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "./index.js",
+  "rules": {
+    // disable requiring trailing commas because it might be nice to revert to
+    // being JSON at some point, and I don't want to make big changes now.
+    "comma-dangle": 0
+  },
+}

--- a/packages/eslint-config-airbnb-next/README.md
+++ b/packages/eslint-config-airbnb-next/README.md
@@ -1,0 +1,49 @@
+# eslint-config-airbnb
+
+[![npm version](https://badge.fury.io/js/eslint-config-airbnb-next.svg)](http://badge.fury.io/js/eslint-config-airbnb-next)
+
+This package provides Airbnb's .eslintrc as an extensible shared config with support for Flowtype.
+
+## Usage
+
+We export three ESLint configurations for your usage.
+
+### eslint-config-airbnb
+
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`.
+
+1. Ensure packages are installed with correct version numbers by running:
+  ```sh
+  (
+    export PKG=eslint-config-airbnb;
+    npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
+  )
+  ```
+
+  Which produces and runs a command like:
+
+  ```sh
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
+  ```
+
+2. Add `"extends": "airbnb"` to your .eslintrc
+
+### eslint-config-airbnb/base
+
+This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+
+### eslint-config-airbnb/legacy
+
+This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+
+See [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript) and
+the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
+for more information.
+
+## Improving this config
+
+Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc?
+
+You can run tests with `npm test`.
+
+You can make sure this module lints with itself using `npm run lint`.

--- a/packages/eslint-config-airbnb-next/index.js
+++ b/packages/eslint-config-airbnb-next/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: [
+    'eslint-config-airbnb',
+    './rules/flowtype',
+  ].map(require.resolve),
+  rules: {}
+};

--- a/packages/eslint-config-airbnb-next/package.json
+++ b/packages/eslint-config-airbnb-next/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "eslint-config-airbnb-next",
+  "version": "13.0.0",
+  "description": "Airbnb's ESLint config, following our styleguide, including Flowtype support.",
+  "main": "index.js",
+  "scripts": {
+    "prelint": "editorconfig-tools check * rules/* test/*",
+    "lint": "eslint .",
+    "tests-only": "babel-tape-runner ./test/test-*.js",
+    "prepublish": "(in-install || eslint-find-rules --unused) && (not-in-publish || npm test) && safe-publish-latest",
+    "pretest": "npm run --silent lint",
+    "test": "npm run --silent tests-only",
+    "travis": "cd ../eslint-config-airbnb && npm install && npm link && cd - && npm link eslint-config-airbnb && npm run --silent test ; npm unlink eslint-config-airbnb >/dev/null &"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/airbnb/javascript"
+  },
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "config",
+    "airbnb",
+    "javascript",
+    "styleguide",
+    "flowtype"
+  ],
+  "author": "Miles Johnson (https://twitter.com/mileswjohnson)",
+  "contributors": [
+    {
+      "name": "Jake Teton-Landis",
+      "url": "https://twitter.com/jitl"
+    },
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com",
+      "url": "http://ljharb.codes"
+    },
+    {
+      "name": "Harrison Shoff",
+      "url": "https://twitter.com/hshoff"
+    },
+    {
+      "name": "Miles Johnson",
+      "url": "https://twitter.com/mileswjohnson"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/airbnb/javascript/issues"
+  },
+  "homepage": "https://github.com/airbnb/javascript",
+  "dependencies": {
+    "eslint-config-airbnb": "^13.0.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "^7.1.1",
+    "babel-preset-airbnb": "^2.1.1",
+    "babel-tape-runner": "^2.0.1",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^3.12.1",
+    "eslint-find-rules": "^1.14.3",
+    "eslint-plugin-flowtype": "^2.29.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.8.0",
+    "in-publish": "^2.0.0",
+    "react": ">= 0.13.0",
+    "safe-publish-latest": "^1.1.1",
+    "tape": "^4.6.3"
+  },
+  "peerDependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.12.1",
+    "eslint-plugin-flowtype": "^2.29.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.8.0"
+  },
+  "engines": {
+    "node": ">= 4"
+  }
+}

--- a/packages/eslint-config-airbnb-next/rules/flowtype.js
+++ b/packages/eslint-config-airbnb-next/rules/flowtype.js
@@ -1,0 +1,80 @@
+module.exports = {
+  parser: 'babel-eslint',
+  plugins: [
+    'flowtype',
+  ],
+  settings: {
+    flowtype: {
+      onlyFilesWithFlowAnnotation: true,
+    },
+  },
+  // Rules: https://github.com/gajus/eslint-plugin-flowtype
+  rules: {
+    // Use `boolean` over `bool`
+    'flowtype/boolean-style': 'error',
+
+    // Require trailing commas
+    'flowtype/delimiter-dangle': ['error', 'always-multiline'],
+
+    // No spacing around generics
+    'flowtype/generic-spacing': ['error', 'never'],
+
+    // No duplicate object properties
+    'flowtype/no-dupe-keys': 'error',
+
+    // No primitive built-in types
+    'flowtype/no-primitive-constructor-types': 'error',
+
+    // Dont allow `any` or `Function` type hints
+    'flowtype/no-weak-types': ['error', {
+      any: true,
+      Object: false,
+      Function: true,
+    }],
+
+    // Use commas instead of semicolons
+    'flowtype/object-type-delimiter': ['error', 'comma'],
+
+    // Require param type hints
+    'flowtype/require-parameter-type': ['error', {
+      excludeArrowFunctions: 'expressionsOnly',
+    }],
+
+    // Require return type hints
+    'flowtype/require-return-type': ['error', {
+      excludeArrowFunctions: 'expressionsOnly',
+    }],
+
+    // Require variable type hints
+    'flowtype/require-variable-type': 'error',
+
+    // Require @flow comment
+    'flowtype/require-valid-file-annotation': ['error', 'always'],
+
+    // Require semicolon
+    'flowtype/semi': ['error', 'always'],
+
+    // Sort object properties
+    'flowtype/sort-keys': ['error', 'asc', {
+      natural: true,
+    }],
+
+    // Require space after type colon
+    'flowtype/space-after-type-colon': ['error', 'always', {
+      allowLineBreak: false,
+    }],
+
+    // Require no space before
+    'flowtype/space-before-type-colon': ['error', 'never'],
+
+    // Require space around unions
+    'flowtype/union-intersection-spacing': ['error', 'always'],
+
+    // Dont enforce name formatting
+    'flowtype/flowtype/type-id-match': 'off',
+
+    // Resolve unused var issues
+    'flowtype/define-flow-type': 'error',
+    'flowtype/use-flow-type': 'error',
+  },
+};

--- a/packages/eslint-config-airbnb-next/test/test-base.js
+++ b/packages/eslint-config-airbnb-next/test/test-base.js
@@ -1,0 +1,16 @@
+import test from 'tape';
+import index from '../';
+
+test('inherits from config-airbnb', (t) => {
+  const actual = index.extends.filter(e => e.indexOf('eslint-config-airbnb/index') >= 0).length;
+
+  t.equal(actual, 1, 'extends eslint-config-airbnb');
+  t.end();
+});
+
+test('inclues flowtype rules', (t) => {
+  const actual = index.extends.filter(e => e.indexOf('rules/flowtype') >= 0).length;
+
+  t.equal(actual, 1, 'extends flowtype');
+  t.end();
+});


### PR DESCRIPTION
I use flowtype on all my personal projects, as well as a few projects at Airbnb. It gets pretty tiring to repeat the same setup across all projects, so I thought it would be best to standardize this through a new official Airbnb ESLint package.

I wasn't sure what to call this package, so I called it "eslint-config-airbnb-next", as it implies it's the next stage / future support (and follows the naming of ESNext). Furthermore, it inherits from "eslint-config-airbnb", so includes react, a11y, and import support automatically. Not sure if this is wanted, but it avoids the following 4 packages: base, react, flow, react+flow, but I can switch to that too if need be.

Also didn't modify the readme as I'm not sure how to phrase it.