### PR TITLE
Updates peerDependencies for eslint-config-airbnb

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -49,7 +49,7 @@
     "babel-preset-airbnb": "^2.1.1",
     "babel-tape-runner": "^2.0.1",
     "editorconfig-tools": "^0.1.1",
-    "eslint": "^3.12.1",
+    "eslint": "^3.12.2",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
     "in-publish": "^2.0.0",
@@ -57,7 +57,7 @@
     "tape": "^4.6.3"
   },
   "peerDependencies": {
-    "eslint": "^3.12.1",
+    "eslint": "^3.12.2",
     "eslint-plugin-import": "^2.2.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -52,10 +52,10 @@
     "babel-preset-airbnb": "^2.1.1",
     "babel-tape-runner": "^2.0.1",
     "editorconfig-tools": "^0.1.1",
-    "eslint": "^3.12.1",
+    "eslint": "^3.12.2",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^3.0.1",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.8.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
@@ -63,8 +63,8 @@
     "tape": "^4.6.3"
   },
   "peerDependencies": {
-    "eslint": "^3.12.1",
-    "eslint-plugin-jsx-a11y": "^3.0.1",
+    "eslint": "^3.12.2",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.8.0"
   },


### PR DESCRIPTION
Updates peerDependencies for eslint-config-airbnb.
Also since the last NPM release has a severely outdated peerDependency for eslint-plugin-jsx-a11y, can we please get a new NPM release with this update?

Thanks!