### PR TITLE
linebreak-style makes it impossible for Windows users to contribute

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -121,10 +121,6 @@ module.exports = {
       applyDefaultPatterns: true,
     }],
 
-    // disallow mixed 'LF' and 'CRLF' as linebreaks
-    // http://eslint.org/docs/rules/linebreak-style
-    'linebreak-style': ['error', 'unix'],
-
     // enforces empty lines around comments
     'lines-around-comment': 'off',
 


### PR DESCRIPTION
Any project that currently uses eslint-config-airbnb checked out on Windows results in thousands of linter errors since the line endings will be CRLF, making it impossible to contribute to these projects as a Windows user without nerfing the linter entirely.

A better way to enforce this is not via a linter, but via a .gitattributes file (https://help.github.com/articles/dealing-with-line-endings). When you do this, Git will ensure the repo internally is LF, but on Win32 will check out files as CRLF (this is a builtin case of a clean/smudge filter)

Refs zeit/hyper#1230, https://github.com/sindresorhus/eslint-config-xo/pull/35