### PR TITLE
[eslint config] [base] Update a deprecated option

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -37,7 +37,7 @@ module.exports = {
 
     // require the use of === and !==
     // http://eslint.org/docs/rules/eqeqeq
-    eqeqeq: ['error', 'allow-null'],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
 
     // make sure for-in loops have an if statement
     'guard-for-in': 'error',


### PR DESCRIPTION
http://eslint.org/docs/rules/eqeqeq#allow-null
https://github.com/eslint/eslint/commit/3e879fcca2c74d63adb5bc66344fa6f8d035e5e6

`allow-null` option is deprecated.