### PR TITLE
[breaking] `padded-blocks`: enable `allowSingleLineBlocks` option

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -419,12 +419,12 @@ module.exports = {
     'operator-linebreak': ['error', 'before', { overrides: { '=': 'none' } }],
 
     // disallow padding within blocks
-    // TODO, semver-major: uncomment option
     'padded-blocks': ['error', {
       blocks: 'never',
       classes: 'never',
       switches: 'never',
-      // allowSingleLineBlocks: true,
+    }, {
+      allowSingleLineBlocks: true,
     }],
 
     // Require or disallow padding lines between statements


### PR DESCRIPTION
This Pull request is to fix #1240. This will enable no padding for switch statements and class declarations along with blocks.

Reference : http://eslint.org/docs/rules/padded-blocks

