### PR TITLE
Avoid octal number interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,10 +811,10 @@ Other Style Guides
     console.log(...x);
 
     // bad
-    new (Function.prototype.bind.apply(Date, [null, 2016, 08, 05]));
+    new (Function.prototype.bind.apply(Date, [null, 2016, 8, 5]));
 
     // good
-    new Date(...[2016, 08, 05]);
+    new Date(...[2016, 8, 5]);
     ```
 
   <a name="functions--signature-invocation-indentation"></a>


### PR DESCRIPTION
- Some JavaScript versions interpret numbers as octal if they are written with a leading zero.
- Babel interpreter throws with an `Invalid number` message.