### PR TITLE
Update react.js

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -52,7 +52,7 @@ module.exports = {
 
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
-    'react/jsx-curly-spacing': ['error', 'never', { allowMultiline: true }],
+    'react/jsx-curly-spacing': ['error', 'never'],
 
     // Enforce event handler naming conventions in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md


### PR DESCRIPTION
According to the eslint-plugin-react docs allowMultiline has a default value to be true.

By default, braces spanning multiple lines are allowed with either setting. If you want to disallow them you can specify an additional allowMultiline property with the value false.