### PR TITLE
[guide] Correct erroneous example

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,8 +883,7 @@ Other Style Guides
     ```javascript
     // bad
     [1, 2, 3].map(number => {
-      const nextNumber = number + 1;
-      `A string containing the ${nextNumber}.`;
+      return `A string containing the ${number}.`;
     });
 
     // good
@@ -898,7 +897,7 @@ Other Style Guides
 
     // good
     [1, 2, 3].map((number, index) => ({
-      [index]: number
+      [index]: number,
     }));
     ```
 


### PR DESCRIPTION
Currently, the bad example in the [8.2](https://github.com/airbnb/javascript/blob/master/README.md#arrows--implicit-return) is just a wrong example:
```js
[1, 2, 3].map(number => {
  const nextNumber = number + 1;
  `A string containing the ${nextNumber}.`;
});

// returns [ undefined, undefined, undefined ]
```
Maybe this is a copy-paste artifact. I dare to assume and restore what it should be initially.

Also, a trailing comma is added in the object literal.