### PR TITLE
Improve getter/setter regex for react/sort-comp

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -208,7 +208,7 @@ module.exports = {
         'static-methods',
         'lifecycle',
         '/^on.+$/',
-        '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+        '/^(get|set)\s(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
         'everything-else',
         '/^render.+$/',
         'render'


### PR DESCRIPTION
Before, the getter/setter regex was matching on methods named like `setFoo` and `getFoo`, which resulted in confusing warnings like:
```
error  methodFoo should be placed after setFoo  react/sort-comp
```

After this change, the regex only matches lines with whitespace in between `get` or `set` and the name of the setter.