### PR TITLE
[guide] README update for JSCS deprecated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3098,7 +3098,7 @@ Other Style Guides
   - Code Style Linters
     + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
     + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
-    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
+    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) (Deprecated, please use [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base))
 
 **Other Style Guides**
 


### PR DESCRIPTION
Created pull request after receiving permission from this created issue: https://github.com/airbnb/javascript/issues/1272

Just letting people know up front that the JSCS style guides are deprecated and to use the eslint style guides from now on.