### PR TITLE
The good case example on switch blocks did not use braces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,9 +1818,10 @@ Other Style Guides
         }
         break;
       }
-      case 4:
+      case 4: {
         bar();
         break;
+      }
       default: {
         class C {}
       }


### PR DESCRIPTION
`case 4` did not use braces.