### PR TITLE
[guide] Use const in README when not reassigning reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,7 +1588,7 @@ Other Style Guides
     ```javascript
     // bad
 
-    let array = [1, 2, 3];
+    const array = [1, 2, 3];
     let num = 1;
     num++;
     --num;
@@ -1605,7 +1605,7 @@ Other Style Guides
 
     // good
 
-    let array = [1, 2, 3];
+    const array = [1, 2, 3];
     let num = 1;
     num += 1;
     num -= 1;


### PR DESCRIPTION
According to the section [2.2](https://github.com/airbnb/javascript#references--prefer-const) of the guide, `const` is preferred.

This change contributes to the internal consistency.