### PR TITLE
Changed from array to single value

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -233,7 +233,7 @@ module.exports = {
 
     // disallow use of chained assignment expressions
     // http://eslint.org/docs/rules/no-multi-assign
-    'no-multi-assign': ['error'],
+    'no-multi-assign': 'error',
 
     // disallow multiple empty lines and only one newline at the end
     'no-multiple-empty-lines': ['error', { max: 2, maxEOF: 1 }],


### PR DESCRIPTION
This being an array with only one value was causing an error in Atom's internal linter. It would throw errors on the 1st line of code stating there was no rule defined for `no-multi-assign`. When I added a rule in my local `.eslintrc.json` it simply delivered the same error in whatever level I declared. The only way for me to get rid of it was to set it to `0`; which was less than ideal since I wanted it to be where you have it, at `2` (`error`).

I eventually traced it all the way back to this config as our own config extends this one, changed the array to a string in the live project and it finally stopped throwing inline errors in Atom.

I will say that it's odd that the CLI didn't report an issue...so perhaps it's just an Atom interpretation issue of having an array with no other values.