### PR TITLE
Update renamed jsx-wrap-multilines

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -392,7 +392,7 @@
 
 ## Parentheses
 
-  - Wrap JSX tags in parentheses when they span more than one line. eslint: [`react/wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md)
+  - Wrap JSX tags in parentheses when they span more than one line. eslint: [`react/jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
 
     ```jsx
     // bad


### PR DESCRIPTION
`react/wrap-multilines` has been renamed to `react/jsx-wrap-multilines`

Broken Link: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md

New Link: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md