### PR TITLE
[resources] add link to neutrino preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -3099,6 +3099,7 @@ Other Style Guides
     + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
     + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
     + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) (Deprecated, please use [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base))
+  - Neutrino preset - [neutrino-preset-airbnb-base](https://neutrino.js.org/presets/neutrino-preset-airbnb-base/)
 
 **Other Style Guides**
 


### PR DESCRIPTION
[Neutrino](https://neutrino.js.org/) is a cool new project from Mozilla for creating and building modern JS apps with zero configuration.

[What is the added value versus all the boilerplate projects out there like create-react-app?](https://neutrino.js.org/FAQ.html#what-is-the-added-value-versus-all-the-boilerplate-projects-out-there-like-create-react-app) is worth a read.

Neutrino already has an Airbnb base preset here: https://neutrino.js.org/presets/neutrino-preset-airbnb-base/ and supports customization as outlined in this "turning off semis required" example: https://neutrino.js.org/presets/neutrino-preset-airbnb-base/#simple-customization