### PR TITLE
Add type-annotations to react/sort-comp

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -207,6 +207,7 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     'react/sort-comp': ['error', {
       order: [
+        'type-annotations',
         'static-methods',
         'lifecycle',
         '/^on.+$/',


### PR DESCRIPTION
This adds the `type-annotations` to the top of the `react/sort-comp` list. The [rule options](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md#rule-options) have a pretty good example of this.

🤘 