### PR TITLE
Use no-param-reassign's ignorePropertyModificationsFor option

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -164,9 +164,21 @@ module.exports = {
     'no-octal-escape': 'error',
 
     // disallow reassignment of function parameters
-    // disallow parameter object manipulation
+    // disallow parameter object manipulation except for specific exclusions
     // rule: http://eslint.org/docs/rules/no-param-reassign.html
-    'no-param-reassign': ['error', { props: true }],
+    'no-param-reassign': ['error', {
+      props: true,
+      ignorePropertyModificationsFor: [
+        'acc', // for reduce accumulators
+        'e', // for e.returnvalue
+        'ctx', // for Koa routing
+        'req', // for Express requests
+        'request', // for Express requests
+        'res', // for Express responses
+        'response', // for Express responses
+        '$scope', // for Angular 1 scopes
+      ]
+    }],
 
     // disallow usage of __proto__ property
     'no-proto': 'error',


### PR DESCRIPTION
This adds exceptions to `no-param-reassign` to resolve #1217. There's probably some discussion to be done around which variables should be ignored, but currently I've added `req`, `request`, and `$scope` from [this comment](https://github.com/airbnb/javascript/issues/1217#issuecomment-268441966).

Please let me know if you have any questions, or if there are any changes you'd like for me to make. Thanks!

Closes #1217