### PR TITLE
Fix dot-notation rule with non id props

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -29,7 +29,7 @@ module.exports = {
     'default-case': ['error', { commentPattern: '^no default$' }],
 
     // encourages use of dot notation whenever possible
-    'dot-notation': ['error', { allowKeywords: true, 'allowPattern': '[^a-zA-Z0-9\_\$]' }],
+    'dot-notation': ['error', { allowKeywords: true, 'allowPattern': '[^a-zA-Z0-9_$]' }],
 
     // enforces consistent newlines before or after dots
     // http://eslint.org/docs/rules/dot-location

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -29,7 +29,7 @@ module.exports = {
     'default-case': ['error', { commentPattern: '^no default$' }],
 
     // encourages use of dot notation whenever possible
-    'dot-notation': ['error', { allowKeywords: true }],
+    'dot-notation': ['error', { allowKeywords: true, 'allowPattern': '[^a-zA-Z0-9\_\$]' }],
 
     // enforces consistent newlines before or after dots
     // http://eslint.org/docs/rules/dot-location

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -29,7 +29,7 @@ module.exports = {
     'default-case': ['error', { commentPattern: '^no default$' }],
 
     // encourages use of dot notation whenever possible
-    'dot-notation': ['error', { allowKeywords: true, 'allowPattern': '[^a-zA-Z0-9_$]' }],
+    'dot-notation': ['error', { allowKeywords: true, allowPattern: '[^a-zA-Z0-9_$]' }],
 
     // enforces consistent newlines before or after dots
     // http://eslint.org/docs/rules/dot-location


### PR DESCRIPTION
Fix dot-notation rule with non id props:
```javascript
const data = {};
data['foo-bar'] = 1;
```