### PR TITLE
.eslintrc deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3135,7 +3135,7 @@ Other Style Guides
 **Tools**
 
   - Code Style Linters
-    + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
+    + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc.js](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc.js)
     + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
     + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) (Deprecated, please use [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base))
   - Neutrino preset - [neutrino-preset-airbnb-base](https://neutrino.js.org/presets/neutrino-preset-airbnb-base/)

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -1,4 +1,4 @@
-// Use this file as a starting point for your project's .eslintrc.
+// Use this file as a starting point for your project's .eslintrc.js.
 // Copy this file, and add rule overrides as needed.
 {
   "extends": "airbnb"

--- a/linters/.eslintrc.js
+++ b/linters/.eslintrc.js
@@ -1,5 +1,5 @@
 // Use this file as a starting point for your project's .eslintrc.js.
 // Copy this file, and add rule overrides as needed.
-{
+module.exports = {
   "extends": "airbnb"
 }

--- a/packages/eslint-config-airbnb-base/.eslintrc.js
+++ b/packages/eslint-config-airbnb-base/.eslintrc.js
@@ -1,8 +1,8 @@
-{
+module.exports = {
   "extends": "./index.js",
   "rules": {
     // disable requiring trailing commas because it might be nice to revert to
     // being JSON at some point, and I don't want to make big changes now.
     "comma-dangle": 0
-  }
+  },
 }

--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/eslint-config-airbnb-base.svg)](http://badge.fury.io/js/eslint-config-airbnb-base)
 
-This package provides Airbnb's base JS .eslintrc as an extensible shared config.
+This package provides Airbnb's base JS .eslintrc.js as an extensible shared config.
 
 ## Usage
 
@@ -45,7 +45,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
   ```
 
-2. Add `"extends": "airbnb-base"` to your .eslintrc
+2. Add `"extends": "airbnb-base"` to your .eslintrc.js
 
 ### eslint-config-airbnb-base/legacy
 
@@ -71,13 +71,13 @@ Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
   npm install --save-dev eslint-config-airbnb-base eslint@^3.0.1 eslint-plugin-import@^1.10.3
   ```
 
-2. Add `"extends": "airbnb-base/legacy"` to your .eslintrc
+2. Add `"extends": "airbnb-base/legacy"` to your .eslintrc.js
 
 See [Airbnb's overarching ESLint config](https://npmjs.com/eslint-config-airbnb), [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript), and the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.
 
 ## Improving this config
 
-Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc?
+Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc.js?
 
 You can run tests with `npm test`.
 

--- a/packages/eslint-config-airbnb-base/test/.eslintrc.js
+++ b/packages/eslint-config-airbnb-base/test/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "rules": {
     // disabled because I find it tedious to write tests while following this rule
     "no-shadow": 0,

--- a/packages/eslint-config-airbnb/.eslintrc.js
+++ b/packages/eslint-config-airbnb/.eslintrc.js
@@ -1,8 +1,8 @@
-{
+module.exports = {
   "extends": "./index.js",
   "rules": {
     // disable requiring trailing commas because it might be nice to revert to
     // being JSON at some point, and I don't want to make big changes now.
     "comma-dangle": 0
-  },
+  }
 }

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/eslint-config-airbnb.svg)](http://badge.fury.io/js/eslint-config-airbnb)
 
-This package provides Airbnb's .eslintrc as an extensible shared config.
+This package provides Airbnb's .eslintrc.js as an extensible shared config.
 
 ## Usage
 
@@ -46,7 +46,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
   ```
 
-2. Add `"extends": "airbnb"` to your .eslintrc
+2. Add `"extends": "airbnb"` to your .eslintrc.js
 
 ### eslint-config-airbnb/base
 
@@ -62,7 +62,7 @@ for more information.
 
 ## Improving this config
 
-Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc?
+Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc.js?
 
 You can run tests with `npm test`.
 

--- a/packages/eslint-config-airbnb/test/.eslintrc.js
+++ b/packages/eslint-config-airbnb/test/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "rules": {
     // disabled because I find it tedious to write tests while following this rule
     "no-shadow": 0,


### PR DESCRIPTION
`.eslintrc` is deprecated in favor of `.eslintrc.js`

http://eslint.org/docs/user-guide/configuring#configuration-file-formats