### PR TITLE
Fix the example of "propTypes"

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -360,8 +360,8 @@
   };
 
   // good
-  function SFC({ foo, bar }) {
-    return <div>{foo}{bar}</div>;
+  function SFC({ foo, bar, children }) {
+    return <div>{foo}{bar}{children}</div>;
   }
   SFC.propTypes = {
     foo: PropTypes.number.isRequired,


### PR DESCRIPTION
This example makes me confused. I guess it missed the use of "children" of good code.
Is the example to explain that you should specify default values for non-required props?

Thanks