### PR TITLE
Fix error on function within 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ Other Style Guides
     });
 
     // good
-    [1, 2, 3].map(number => `A string containing the ${number}.`);
+    [1, 2, 3].map(number => `A string containing the ${number + 1}.`);
 
     // good
     [1, 2, 3].map((number) => {


### PR DESCRIPTION
The function in place as `bad` example is
```javascript
[1, 2, 3].map(number => {
  const nextNumber = number + 1;
  `A string containing the ${nextNumber}.`;
});
```
But the one proposed as `good` example missed the `+ 1` operator
```javascript
[1, 2, 3].map(number => `A ${number}`);
```