### PR TITLE
Use dangling comma in the diff example for dangling commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -2478,14 +2478,14 @@ Other Style Guides
          firstName: 'Florence',
     -    lastName: 'Nightingale'
     +    lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'modern nursing']
+    +    inventorOf: ['coxcomb chart', 'modern nursing',]
     };
 
     // good - git diff with trailing comma
     const hero = {
          firstName: 'Florence',
          lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'modern nursing'],
+    +    inventorOf: ['coxcomb chart', 'modern nursing',],
     };
     ```
 


### PR DESCRIPTION
Seemed inconsistent to say "use dangling commas" but then not include dangling commas in the example diff.