### PR TITLE
Turn `ignorePureComponent` option on for react/prefer-stateless-function

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -176,7 +176,7 @@ module.exports = {
 
     // Require stateless functions when not using lifecycle methods, setState or ref
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
-    'react/prefer-stateless-function': 'error',
+    'react/prefer-stateless-function': ['error', { ignorePureComponent: true }],
 
     // Prevent missing props validation in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md


### PR DESCRIPTION
Otherwise, there is no way to write pure components that don't use state, refs, or lifecycle methods.

Stateless functions are not treated internally as pure components, and are rerendered every time.