### PR TITLE
Fix React code examples; ref cb and semicolons

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -476,7 +476,7 @@
       }
 
       render() {
-        return <div onClick={this.onClickDiv.bind(this)} />
+        return <div onClick={this.onClickDiv.bind(this)} />;
       }
     }
 
@@ -493,7 +493,7 @@
       }
 
       render() {
-        return <div onClick={this.onClickDiv} />
+        return <div onClick={this.onClickDiv} />;
       }
     }
     ```
@@ -575,7 +575,7 @@
       }
 
       render() {
-        return <a href={this.props.url} data-id={this.props.id}>{this.props.text}</a>
+        return <a href={this.props.url} data-id={this.props.id}>{this.props.text}</a>;
       }
     }
 


### PR DESCRIPTION
- Added missing semicolons
- ~~Simplified `ref` callback example by removing parentheses and curly braces~~
- ~~Removed wrapping parentheses from `render` `return` element~~