### PR TITLE
Add rollup.config.*.js to import/no-extraneous-dependencies ignore list

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -80,6 +80,7 @@ module.exports = {
         '**/webpack.config.js', // webpack config
         '**/webpack.config.*.js', // webpack config
         '**/rollup.config.js', // rollup config
+        '**/rollup.config.*.js', // rollup config
         '**/gulpfile.js', // gulp config
         '**/gulpfile.*.js', // gulp config
         '**/Gruntfile', // grunt config


### PR DESCRIPTION
As other tools, it's fairly common to have multiple Rollup configuration files. This pattern seems to be used by Rollup in [their own configuration](https://github.com/rollup/rollup/blob/master/rollup.config.cli.js).