### PR TITLE
Remove "simply" from Readme

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -18,7 +18,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   npm info "eslint-config-airbnb@latest" peerDependencies
   ```
 
-  Linux/OSX users can simply run
+  Linux/OSX users can run
 
   ```sh
   (


### PR DESCRIPTION
Our usage of "simply" in the Readme was called out on Twitter today https://twitter.com/iamsapegin/status/856880857570832384?s=09. Best to avoid its use since what is "simple" is relative. 

