### PR TITLE
Remove "simply" from Readme in base

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -57,7 +57,7 @@ Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
   npm info "eslint-config-airbnb-base@latest" peerDependencies
   ```
 
-  Linux/OSX users can simply run
+  Linux/OSX users can run
   ```sh
   (
     export PKG=eslint-config-airbnb-base;


### PR DESCRIPTION
Second instance of "simply":

Our usage of "simply" in the Readme was called out on Twitter today https://twitter.com/iamsapegin/status/856880857570832384?s=09. Best to avoid its use since what is "simple" is relative.

txtx @jongold