### PR TITLE
Disallow unused global variables

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -34,7 +34,7 @@ module.exports = {
     'no-undefined': 'off',
 
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': ['error', { vars: 'local', args: 'after-used', ignoreRestSiblings: true }],
+    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
 
     // disallow use of variables before they are defined
     'no-use-before-define': ['error', { functions: true, classes: true, variables: true }],


### PR DESCRIPTION
The current configuration allows unused global variables for unknown reason as stated [here](https://github.com/facebookincubator/create-react-app/issues/1719#issuecomment-286654527)

As stated [here](https://github.com/facebookincubator/create-react-app/issues/1719#issuecomment-285043565) the current config allows this behaviour because it was default in eslint.

But since eslint has changed the defaults to warn on any unused variable local/global, we should update this config to use new defaults.