### PR TITLE
Blacklist confusing globals

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -62,5 +62,8 @@
   },
   "engines": {
     "node": ">= 4"
+  },
+  "dependencies": {
+    "eslint-restricted-globals": "^0.1.1"
   }
 }

--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -1,3 +1,5 @@
+const restrictedGlobals = require('eslint-restricted-globals');
+
 module.exports = {
   rules: {
     // enforce or disallow variable initializations at definition
@@ -14,7 +16,7 @@ module.exports = {
     'no-label-var': 'error',
 
     // disallow specific globals
-    'no-restricted-globals': 'off',
+    'no-restricted-globals': ['error'].concat(restrictedGlobals),
 
     // disallow declaration of variables already declared in the outer scope
     'no-shadow': 'error',


### PR DESCRIPTION
Blacklist confusing global variables set by browser env as discussed [here](https://github.com/facebookincubator/create-react-app/pull/2130#issuecomment-302808156).
