### PR TITLE
[6.5] Add no-eval eslint rule to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Other Style Guides
     ```
 
   <a name="strings--eval"></a><a name="6.5"></a>
-  - [6.4](#strings--eval) Never use `eval()` on a string, it opens too many vulnerabilities.
+  - [6.4](#strings--eval) Never use `eval()` on a string, it opens too many vulnerabilities. eslint: [`no-eval`](http://eslint.org/docs/rules/no-eval)
 
   <a name="strings--escaping"></a>
   - [6.5](#strings--escaping) Do not unnecessarily escape characters in strings. eslint: [`no-useless-escape`](http://eslint.org/docs/rules/no-useless-escape)


### PR DESCRIPTION
Add reference to the eslint `no-eval` rule to the README.

This rule is already set to `error` in best-practices.js in eslint-airbnb-config-base.