### PR TITLE
[eslint config] [eslint config base] Additional test extensions.

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -73,10 +73,9 @@ module.exports = {
         'tests/**', // also common npm pattern
         'spec/**', // mocha, rspec-like pattern
         '**/__tests__/**', // jest pattern
-        'test.js', // repos with a single test file
-        'test-*.js', // repos with multiple top-level test files
-        '**/*.test.js', // tests where the extension denotes that it is a test
-        '**/*.spec.js', // tests where the extension denotes that it is a test
+        'test.{js,jsx}', // repos with a single test file
+        'test-*.{js,jsx}', // repos with multiple top-level test files
+        '**/*.{test,spec}.{js,jsx}', // tests where the extension denotes that it is a test
         '**/webpack.config.js', // webpack config
         '**/webpack.config.*.js', // webpack config
         '**/rollup.config.js', // rollup config


### PR DESCRIPTION
I did some searching and didn't see any discussion about this. I'd like to have `*.test.jsx` files in my project so that I can have tests with JSX that don't interfere with `react/jsx-filename-extension`.