### PR TITLE
Add linting for Markdown prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Other Style Guides
- - [ES5 (Deprecated)](https://github.com/airbnb/javascript/tree/es5-deprecated/es5)
- - [React](react/)
- - [CSS-in-JavaScript](css-in-javascript/)
- - [CSS & Sass](https://github.com/airbnb/css)
- - [Ruby](https://github.com/airbnb/ruby)
+
+  - [ES5 (Deprecated)](https://github.com/airbnb/javascript/tree/es5-deprecated/es5)
+  - [React](react/)
+  - [CSS-in-JavaScript](css-in-javascript/)
+  - [CSS & Sass](https://github.com/airbnb/css)
+  - [Ruby](https://github.com/airbnb/ruby)
 
 ## Table of Contents
 
@@ -58,11 +59,11 @@ Other Style Guides
   <a name="types--primitives"></a><a name="1.1"></a>
   - [1.1](#types--primitives) **Primitives**: When you access a primitive type you work directly on its value.
 
-    + `string`
-    + `number`
-    + `boolean`
-    + `null`
-    + `undefined`
+    - `string`
+    - `number`
+    - `boolean`
+    - `null`
+    - `undefined`
 
     ```javascript
     const foo = 1;
@@ -76,9 +77,9 @@ Other Style Guides
   <a name="types--complex"></a><a name="1.2"></a>
   - [1.2](#types--complex)  **Complex**: When you access a complex type you work on a reference to its value.
 
-    + `object`
-    + `array`
-    + `function`
+    - `object`
+    - `array`
+    - `function`
 
     ```javascript
     const foo = [1, 2];
@@ -524,7 +525,6 @@ Other Style Guides
     const { left, top } = processInput(input);
     ```
 
-
 **[⬆ back to top](#table-of-contents)**
 
 ## Strings
@@ -609,7 +609,6 @@ Other Style Guides
     ```
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Functions
 
@@ -1016,7 +1015,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Classes & Constructors
 
   <a name="constructors--use-class"></a><a name="9.1"></a>
@@ -1034,7 +1032,6 @@ Other Style Guides
       this.queue.splice(0, 1);
       return value;
     };
-
 
     // good
     class Queue {
@@ -1110,7 +1107,6 @@ Other Style Guides
       .setHeight(20);
     ```
 
-
   <a name="constructors--tostring"></a><a name="9.4"></a>
   - [9.4](#constructors--tostring) It's okay to write a custom toString() method, just make sure it works successfully and causes no side effects.
 
@@ -1182,9 +1178,7 @@ Other Style Guides
     }
     ```
 
-
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Modules
 
@@ -1449,7 +1443,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Properties
 
   <a name="properties--dot"></a><a name="12.1"></a>
@@ -1485,7 +1478,6 @@ Other Style Guides
     ```
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Variables
 
@@ -1656,7 +1648,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Hoisting
 
   <a name="hoisting--about"></a><a name="14.1"></a>
@@ -1756,7 +1747,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Comparison Operators & Equality
 
   <a name="comparison--eqeqeq"></a><a name="15.1"></a>
@@ -1765,12 +1755,12 @@ Other Style Guides
   <a name="comparison--if"></a><a name="15.2"></a>
   - [15.2](#comparison--if) Conditional statements such as the `if` statement evaluate their expression using coercion with the `ToBoolean` abstract method and always follow these simple rules:
 
-    + **Objects** evaluate to **true**
-    + **Undefined** evaluates to **false**
-    + **Null** evaluates to **false**
-    + **Booleans** evaluate to **the value of the boolean**
-    + **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
-    + **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
+    - **Objects** evaluate to **true**
+    - **Undefined** evaluates to **false**
+    - **Null** evaluates to **false**
+    - **Booleans** evaluate to **the value of the boolean**
+    - **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
+    - **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
 
     ```javascript
     if ([0] && []) {
@@ -1910,7 +1900,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Blocks
 
   <a name="blocks--braces"></a><a name="16.1"></a>
@@ -1960,9 +1949,7 @@ Other Style Guides
     }
     ```
 
-
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Control Statements
 
@@ -2018,9 +2005,7 @@ Other Style Guides
     }
     ```
 
-
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Comments
 
@@ -2161,7 +2146,6 @@ Other Style Guides
     ```
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Whitespace
 
@@ -2624,7 +2608,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Semicolons
 
   <a name="semicolons--required"></a><a name="20.1"></a>
@@ -2653,7 +2636,6 @@ Other Style Guides
     [Read more](https://stackoverflow.com/questions/7365172/semicolon-before-self-invoking-function/7365214%237365214).
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Type Casting & Coercion
 
@@ -2740,7 +2722,6 @@ Other Style Guides
     ```
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Naming Conventions
 
@@ -2933,7 +2914,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Accessors
 
   <a name="accessors--not-required"></a><a name="23.1"></a>
@@ -3003,7 +2983,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Events
 
   <a name="events--hash"></a><a name="24.1"></a>
@@ -3034,7 +3013,6 @@ Other Style Guides
     ```
 
   **[⬆ back to top](#table-of-contents)**
-
 
 ## jQuery
 
@@ -3105,7 +3083,6 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## ECMAScript 5 Compatibility
 
   <a name="es5-compat--kangax"></a><a name="26.1"></a>
@@ -3153,15 +3130,14 @@ Other Style Guides
 
   <a name="testing--for-real"></a><a name="28.2"></a>
   - [29.2](#testing--for-real) **No, but seriously**:
-   - Whichever testing framework you use, you should be writing tests!
-   - Strive to write many small pure functions, and minimize where mutations occur.
-   - Be cautious about stubs and mocks - they can make your tests more brittle.
-   - We primarily use [`mocha`](https://www.npmjs.com/package/mocha) at Airbnb. [`tape`](https://www.npmjs.com/package/tape) is also used occasionally for small, separate modules.
-   - 100% test coverage is a good goal to strive for, even if it's not always practical to reach it.
-   - Whenever you fix a bug, _write a regression test_. A bug fixed without a regression test is almost certainly going to break again in the future.
+    - Whichever testing framework you use, you should be writing tests!
+    - Strive to write many small pure functions, and minimize where mutations occur.
+    - Be cautious about stubs and mocks - they can make your tests more brittle.
+    - We primarily use [`mocha`](https://www.npmjs.com/package/mocha) at Airbnb. [`tape`](https://www.npmjs.com/package/tape) is also used occasionally for small, separate modules.
+    - 100% test coverage is a good goal to strive for, even if it's not always practical to reach it.
+    - Whenever you fix a bug, _write a regression test_. A bug fixed without a regression test is almost certainly going to break again in the future.
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Performance
 
@@ -3176,7 +3152,6 @@ Other Style Guides
   - Loading...
 
 **[⬆ back to top](#table-of-contents)**
-
 
 ## Resources
 
@@ -3194,9 +3169,9 @@ Other Style Guides
 **Tools**
 
   - Code Style Linters
-    + [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
-    + [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
-    + [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) (Deprecated, please use [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base))
+    - [ESlint](http://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
+    - [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
+    - [JSCS](https://github.com/jscs-dev/node-jscs) - [Airbnb Style Preset](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) (Deprecated, please use [ESlint](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base))
   - Neutrino preset - [neutrino-preset-airbnb-base](https://neutrino.js.org/presets/neutrino-preset-airbnb-base/)
 
 **Other Style Guides**
@@ -3256,7 +3231,6 @@ Other Style Guides
 
   - [JavaScript Air](https://javascriptair.com/)
   - [JavaScript Jabber](https://devchat.tv/js-jabber/)
-
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -3384,7 +3358,6 @@ Other Style Guides
 ## Contributors
 
   - [View Contributors](https://github.com/airbnb/javascript/graphs/contributors)
-
 
 ## License
 

--- a/css-in-javascript/README.md
+++ b/css-in-javascript/README.md
@@ -176,7 +176,6 @@
 
     export default withStyles(() => styles)(MyComponent);
 
-
     // good
     function MyComponent({ styles }) {
       return (

--- a/linters/.markdownlint.json
+++ b/linters/.markdownlint.json
@@ -1,0 +1,154 @@
+{
+  "comment": "Be explicit by listing every available rule. https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md",
+  "comment": "Note that there will be numeric gaps, not every MD number is implemented in markdownlint.",
+
+  "comment": "MD001: Header levels should only increment by one level at a time",
+  "header-increment": true,
+
+  "comment": "MD002: First header should be a top level header",
+  "first-header-h1": true,
+
+  "comment": "MD003: Header style: start with hashes",
+  "header-style": {
+    "style": "atx"
+  },
+
+  "comment": "MD004: Unordered list style",
+  "ul-style": {
+    "style": "dash"
+  },
+
+  "comment": "MD005: Consistent indentation for list items at the same level",
+  "list-indent": true,
+
+  "comment": "MD006: Consider starting bulleted lists at the beginning of the line",
+  "ul-start-left": false,
+
+  "comment": "MD007: Unordered list indentation: 2 spaces",
+  "ul-indent": {
+    "indent": 2
+  },
+
+  "comment": "MD009: Disallow trailing spaces",
+  "no-trailing-spaces": {
+    "br-spaces": 0,
+    "comment": "Empty lines inside list items should not be indented",
+    "list_item_empty_lines": false
+  },
+
+  "comment": "MD010: No hard tabs, not even in code blocks",
+  "no-hard-tabs": {
+    "code_blocks": true
+  },
+
+  "comment": "MD011: Prevent reversed link syntax",
+  "no-reversed-links": true,
+
+  "comment": "MD012: Disallow multiple consecutive blank lines",
+  "no-multiple-blanks": {
+    "maximum": 1
+   },
+
+  "comment": "MD013: Line length",
+  "line-length": false,
+
+  "comment": "MD014: Disallow dollar signs used before commands without showing output",
+  "commands-show-output": true,
+
+  "comment": "MD018: Disallow space after hash on atx style header",
+  "no-missing-space-atx": true,
+
+  "comment": "MD019: Dissalow multiple spaces after hash on atx style header",
+  "no-multiple-space-atx": true,
+
+  "comment": "MD020: No space inside hashes on closed atx style header",
+  "no-missing-space-closed-atx": true,
+
+  "comment": "MD021: Disallow multiple spaces inside hashes on closed atx style header",
+  "no-multiple-space-closed-atx": true,
+
+  "comment": "MD022: Headers should be surrounded by blank lines",
+  "comment": "Some headers have preceeding HTML anchors. Unfortunate that we have to disable this, as it otherwise catches a real problem that trips up some Markdown renderers",
+  "blanks-around-headers": false,
+
+  "comment": "MD023: Headers must start at the beginning of the line",
+  "header-start-left": true,
+
+  "comment": "MD024: Disallow multiple headers with the same content",
+  "no-duplicate-header": true,
+
+  "comment": "MD025: Disallow multiple top level headers in the same document",
+  "comment": "Gotta have a matching closing brace at the end",
+  "single-h1": false,
+
+  "comment": "MD026: Disallow trailing punctuation in header",
+  "comment": "Gotta have a semicolon after the ending closing brace",
+  "no-trailing-punctuation": {
+    "punctuation" : ".,:!?"
+  },
+  "comment": "MD027: Dissalow multiple spaces after blockquote symbol",
+  "no-multiple-space-blockquote": true,
+
+  "comment": "MD028: Blank line inside blockquote",
+  "comment": "Some 'Why?' and 'Why not?' blocks are separated by a blank line",
+  "no-blanks-blockquote": false,
+
+  "comment": "MD029: Ordered list item prefix",
+  "ol-prefix": {
+    "style": "one"
+  },
+
+  "comment": "MD030: Spaces after list markers",
+  "list-marker-space": {
+    "ul_single": 1,
+    "ol_single": 1,
+    "ul_multi": 1,
+    "ol_multi": 1
+  },
+
+  "comment": "MD031: Fenced code blocks should be surrounded by blank lines",
+  "blanks-around-fences": true,
+
+  "comment": "MD032: Lists should be surrounded by blank lines",
+  "comment": "Some lists have preceeding HTML anchors. Unfortunate that we have to disable this, as it otherwise catches a real problem that trips up some Markdown renderers",
+  "blanks-around-lists": false,
+
+  "comment": "MD033: Disallow inline HTML",
+  "comment": "HTML is needed for explicit anchors",
+  "no-inline-html": false,
+
+  "comment": "MD034: No bare URLs used",
+  "no-bare-urls": true,
+
+  "comment": "MD035: Horizontal rule style",
+  "hr-style": {
+    "style": "consistent"
+  },
+
+  "comment": "MD036: Do not use emphasis instead of a header",
+  "no-emphasis-as-header": false,
+
+  "comment": "MD037: Disallow spaces inside emphasis markers",
+  "no-space-in-emphasis": true,
+
+  "comment": "MD038: Disallow spaces inside code span elements",
+  "no-space-in-code": true,
+
+  "comment": "MD039: Disallow spaces inside link text",
+  "no-space-in-links": true,
+
+  "comment": "MD040: Fenced code blocks should have a language specified",
+  "fenced-code-language": true,
+
+  "comment": "MD041: First line in file should be a top level header",
+  "first-line-h1": true,
+
+  "comment": "MD042: No empty links",
+  "no-empty-links": true,
+
+  "comment": "MD043: Required header structure",
+  "required-headers": false,
+
+  "comment": "MD044: Proper names should have the correct capitalization",
+  "proper-names": false
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
     "preinstall": "npm run install:config && npm run install:config:base",
     "install:config": "cd packages/eslint-config-airbnb && npm prune && npm install",
     "install:config:base": "cd packages/eslint-config-airbnb-base && npm prune && npm install",
+    "lint": "markdownlint --config linters/.markdownlint.json README.md */README.md",
+    "pretest": "npm run --silent lint",
     "test": "npm run --silent test:config && npm run --silent test:config:base",
     "test:config": "cd packages/eslint-config-airbnb; npm test",
     "test:config:base": "cd packages/eslint-config-airbnb-base; npm test",
+    "pretravis": "npm run --silent lint",
     "travis": "npm run --silent travis:config && npm run --silent travis:config:base",
     "travis:config": "cd packages/eslint-config-airbnb; npm run travis",
     "travis:config:base": "cd packages/eslint-config-airbnb-base; npm run travis"
@@ -31,5 +34,8 @@
   "bugs": {
     "url": "https://github.com/airbnb/javascript/issues"
   },
-  "homepage": "https://github.com/airbnb/javascript"
+  "homepage": "https://github.com/airbnb/javascript",
+  "devDependencies": {
+    "markdownlint-cli": "^0.3.1"
+  }
 }


### PR DESCRIPTION
I hear you like linting! Why not enforce consistent style for your Markdown prose too?

Like JavaScript linting, Markdown linting can help identify errors or constructs that not all Markdown renderers handle correctly. The linter caught a few bugs in the README.

If you disagree with any of how I've gone about this, please let me know, and I'm happy to change things.

If you disagree with the intent of this completely, then oh well, it was a fun exercise. :smile: 

## Lint Rules

My intent is to codify the existing style being used, rather than to try to change how Markdown is written in this repo.

1. I've set a catchall to enable all of the [Markdownlint Rules](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md) and subsequently disabled ones that don't apply. If you'd instead like an explicit list of rules that do apply (to avoid updates to markdownlint silently adding new rules), I can do that instead.
1. I disabled a rule when it appeared that one of the documents deliberately did not conform to it. (Even if this nonconformance only happened once, I disabled the rule globally rather than for that one occurrence in the document).
1. I changed document content to fix rule nonconformance when it appeared that:
   * There was a legitimate bug in the document (meaning either GitHub or another Markdown renderer would not render something correctly)
   * A rule was followed consistently, except for a few isolated cases

## Implementation

A new `lint` npm script has been added to the top-level `package.json`, and set as a `pretest` script, to match how `lint` scripts in subpackages are handled. The top-level `travis` script now also explicitly invokes `lint`.

There is now a devDependency on `markdownlint-cli` but not `markdownlint`. The [JavaScript implementation of Markdownlint](https://www.npmjs.com/package/markdownlint) is a library only, and unfortunately the CLI wrapper `markdownlint-cli` has a dependency, rather than a peerDependency, on `markdownlint`.

Thanks!
