### PR TITLE
[guide] Add return in .map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ Other Style Guides
     // bad
     [1, 2, 3].map(number => {
       const nextNumber = number + 1;
-      `A string containing the ${nextNumber}.`;
+      return `A string containing the ${nextNumber}.`;
     });
 
     // good


### PR DESCRIPTION
I guess a `return` was missing in the examples of the arrow functions.