### PR TITLE
Balanced spacing for inline block comments

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -395,7 +395,7 @@ module.exports = {
       block: {
         exceptions: ['-', '+'],
         markers: ['=', '!'], // space here to support sprockets directives
-        balanced: false,
+        balanced: true,
       }
     }],
 


### PR DESCRIPTION
Based on issue #1425 and this [comment](https://github.com/airbnb/javascript/issues/1425#issuecomment-304358900).