### PR TITLE
Remove TODO in prefer-reflect as it's deprecated

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/es6.js
+++ b/packages/eslint-config-airbnb-base/rules/es6.js
@@ -124,7 +124,6 @@ module.exports = {
 
     // suggest using Reflect methods where applicable
     // http://eslint.org/docs/rules/prefer-reflect
-    // TODO: enable?
     'prefer-reflect': 'off',
 
     // use rest parameters instead of arguments


### PR DESCRIPTION
Fixes #1451 

From eslint v3.9.0 this option is deprecated, so removing TODO comment questioning enablement.