### PR TITLE
Support Protractor config files in import/no-extraneous-dependencies

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -83,6 +83,7 @@ module.exports = {
         '**/gulpfile.js', // gulp config
         '**/gulpfile.*.js', // gulp config
         '**/Gruntfile', // grunt config
+        '**/protractor.conf.*.js', // protractor config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
Protractor is used to run E2E tests and therefore is considered to be a dev dependency. We should be able to import dev dependencies inside Protractor config files (`protractor.conf.*.js`).