### PR TITLE
Align JavaScript style guide with Newsela's style preferences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2142,7 +2142,7 @@ Other Style Guides
     ```
 
   <a name="whitespace--max-len"></a><a name="18.12"></a>
-  - [18.12](#whitespace--max-len) Avoid having lines of code that are longer than 100 characters (including whitespace). eslint: [`max-len`](http://eslint.org/docs/rules/max-len.html) jscs: [`maximumLineLength`](http://jscs.info/rule/maximumLineLength)
+  - [18.12](#whitespace--max-len) Avoid having lines of code that are longer than 100 characters (including whitespace). For multiline strings, use string templating to avoid concatenating strings. eslint: [`max-len`](http://eslint.org/docs/rules/max-len.html) jscs: [`maximumLineLength`](http://jscs.info/rule/maximumLineLength)
 
     > Why? This ensures readability and maintainability.
 
@@ -2156,6 +2156,10 @@ Other Style Guides
     // good
     const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. ' +
       'Whatever wizard constrains a helpful ally. The counterpart ascends!';
+
+    // best
+    const foo = `Whatever national crop flips the window. The cartoon reverts within the screw.
+      'Whatever wizard constrains a helpful ally. The counterpart ascends!`;
 
     // good
     $.ajax({

--- a/README.md
+++ b/README.md
@@ -1233,7 +1233,7 @@ Other Style Guides
 ## Iterators and Generators
 
   <a name="iterators--nope"></a><a name="11.1"></a>
-  - [11.1](#iterators--nope) Don't use iterators. Prefer JavaScript's higher-order functions like `map()` and `reduce()` instead of loops like `for-of`. eslint: [`no-iterator`](http://eslint.org/docs/rules/no-iterator.html)
+  - [11.1](#iterators--nope) Don't use iterators. Prefer higher-order functions like `map()` and `reduce()` instead of loops like `for-of`. Instead of using the JavaScript built-in functions, use lodash's `_.map` and `_.reduce` for better performance. eslint: [`no-iterator`](http://eslint.org/docs/rules/no-iterator.html)
 
     > Why? This enforces our immutable rule. Dealing with pure functions that return values is easier to reason about than side effects.
 
@@ -1554,7 +1554,7 @@ Other Style Guides
 ## Comparison Operators & Equality
 
   <a name="comparison--eqeqeq"></a><a name="15.1"></a>
-  - [15.1](#comparison--eqeqeq) Use `===` and `!==` over `==` and `!=`. eslint: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq.html)
+  - [15.1](#comparison--eqeqeq) It is acceptable to use use `==` and `!=` over `===` and `!==`, but be wary of type coersion. eslint: [`eqeqeq`](http://eslint.org/docs/rules/eqeqeq.html)
 
   <a name="comparison--if"></a><a name="15.2"></a>
   - [15.2](#comparison--if) Conditional statements such as the `if` statement evaluate their expression using coercion with the `ToBoolean` abstract method and always follow these simple rules:
@@ -1586,18 +1586,21 @@ Other Style Guides
     if (name) {
       // ...stuff...
     }
+    ```
+   <a name="no-length"></a><a name="15.4"></a>
+  - [15.3](#comparison--shortcuts) Don't use `.length` directly, as there's a possibility of returning `undefined`. Use the lodash method `_.size` to calculate size for arrays and objects, which will return 0 in the case that the variable is `undefined`.
 
+    ```javascript
     // bad
     if (collection.length > 0) {
       // ...stuff...
     }
 
     // good
-    if (collection.length) {
+    if (_.size(collection) > 0) {
       // ...stuff...
     }
     ```
-
   <a name="comparison--moreinfo"></a><a name="15.4"></a>
   - [15.4](#comparison--moreinfo) For more information see [Truth Equality and JavaScript](http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll.
 
@@ -1747,7 +1750,7 @@ Other Style Guides
 ## Comments
 
   <a name="comments--multiline"></a><a name="17.1"></a>
-  - [17.1](#comments--multiline) Use `/** ... */` for multi-line comments. Include a description, specify types and values for all parameters and return values.
+  - [17.1](#comments--multiline) Use `/** ... */` for multi-line comments. Include a description, specify types and values for all parameters and return values. When possible, include a comment with a description for each React component.
 
     ```javascript
     // bad

--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ Other Style Guides
     ```javascript
     // bad
     const superman = {
-      default: { clark: 'kent' },
+      default: {clark: 'kent'},
       private: true,
     };
 
     // good
     const superman = {
-      defaults: { clark: 'kent' },
+      defaults: {clark: 'kent'},
       hidden: true,
     };
     ```
@@ -412,7 +412,7 @@ Other Style Guides
 
     // bad
     inbox.filter((msg) => {
-      const { subject, author } = msg;
+      const {subject, author} = msg;
       if (subject === 'Mockingbird') {
         return author === 'Harper Lee';
       } else {
@@ -422,7 +422,7 @@ Other Style Guides
 
     // good
     inbox.filter((msg) => {
-      const { subject, author } = msg;
+      const {subject, author} = msg;
       if (subject === 'Mockingbird') {
         return author === 'Harper Lee';
       }
@@ -451,12 +451,12 @@ Other Style Guides
 
     // good
     function getFullName(user) {
-      const { firstName, lastName } = user;
+      const {firstName, lastName} = user;
       return `${firstName} ${lastName}`;
     }
 
     // best
-    function getFullName({ firstName, lastName }) {
+    function getFullName({firstName, lastName}) {
       return `${firstName} ${lastName}`;
     }
     ```
@@ -493,11 +493,11 @@ Other Style Guides
     // good
     function processInput(input) {
       // then a miracle occurs
-      return { left, right, top, bottom };
+      return {left, right, top, bottom};
     }
 
     // the caller selects only the data they need
-    const { left, top } = processInput(input);
+    const {left, top} = processInput(input);
     ```
 
 
@@ -556,7 +556,7 @@ Other Style Guides
 
     // bad
     function sayHi(name) {
-      return `How are you, ${ name }?`;
+      return `How are you, ${name}?`;
     }
 
     // good
@@ -1104,7 +1104,7 @@ Other Style Guides
     export default AirbnbStyleGuide.es6;
 
     // best
-    import { es6 } from './AirbnbStyleGuide';
+    import {es6} from './AirbnbStyleGuide';
     export default es6;
     ```
 
@@ -1129,11 +1129,11 @@ Other Style Guides
     ```javascript
     // bad
     // filename es6.js
-    export { es6 as default } from './airbnbStyleGuide';
+    export {es6 as default} from './airbnbStyleGuide';
 
     // good
     // filename es6.js
-    import { es6 } from './AirbnbStyleGuide';
+    import {es6} from './AirbnbStyleGuide';
     export default es6;
     ```
 
@@ -1146,10 +1146,10 @@ Other Style Guides
     // bad
     import foo from 'foo';
     // … some other imports … //
-    import { named1, named2 } from 'foo';
+    import {named1, named2} from 'foo';
 
     // good
-    import foo, { named1, named2 } from 'foo';
+    import foo, {named1, named2} from 'foo';
 
     // good
     import foo, {
@@ -1166,11 +1166,11 @@ Other Style Guides
     ```javascript
     // bad
     let foo = 3;
-    export { foo }
+    export {foo}
 
     // good
     const foo = 3;
-    export { foo }
+    export {foo}
     ```
 
   <a name="modules--prefer-default-export"></a>
@@ -2112,14 +2112,14 @@ Other Style Guides
     ```
 
   <a name="whitespace--in-braces"></a><a name="18.11"></a>
-  - [18.11](#whitespace--in-braces) Add spaces inside curly braces. eslint: [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing.html) jscs: [`requireSpacesInsideObjectBrackets`](http://jscs.info/rule/requireSpacesInsideObjectBrackets)
+  - [18.11](#whitespace--in-braces) Do not add spaces inside curly braces. eslint: [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing.html) jscs: [`requireSpacesInsideObjectBrackets`](http://jscs.info/rule/requireSpacesInsideObjectBrackets)
 
     ```javascript
     // bad
-    const foo = {clark: 'kent'};
+    const foo = { clark: 'kent' };
 
     // good
-    const foo = { clark: 'kent' };
+    const foo = {clark: 'kent'};
     ```
 
   <a name="whitespace--max-len"></a><a name="18.12"></a>
@@ -2132,7 +2132,7 @@ Other Style Guides
     const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. Whatever wizard constrains a helpful ally. The counterpart ascends!';
 
     // bad
-    $.ajax({ method: 'POST', url: 'https://airbnb.com/', data: { name: 'John' } }).done(() => console.log('Congratulations!')).fail(() => console.log('You have failed this city.'));
+    $.ajax({ method: 'POST', url: 'https://airbnb.com/', data: {name: 'John'} }).done(() => console.log('Congratulations!')).fail(() => console.log('You have failed this city.'));
 
     // good
     const foo = 'Whatever national crop flips the window. The cartoon reverts within the screw. ' +
@@ -2142,7 +2142,7 @@ Other Style Guides
     $.ajax({
       method: 'POST',
       url: 'https://airbnb.com/',
-      data: { name: 'John' },
+      data: {name: 'John'},
     })
       .done(() => console.log('Congratulations!'))
       .fail(() => console.log('You have failed this city.'));
@@ -2602,7 +2602,7 @@ Other Style Guides
 
     ```javascript
     // good
-    $(this).trigger('listingUpdated', { listingId: listing.id });
+    $(this).trigger('listingUpdated', {listingId: listing.id});
 
     ...
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Other Style Guides
     ```
 
   <a name="strings--line-length"></a><a name="6.2"></a>
-  - [6.2](#strings--line-length) Strings that cause the line to go over 100 characters should be written across multiple lines using string concatenation.
+  - [6.2](#strings--line-length) Strings that cause the line to go over 100 characters should be written across multiple lines using string templating.
 
   <a name="strings--concat-perf"></a><a name="6.3"></a>
   - [6.3](#strings--concat-perf) Note: If overused, long strings with concatenation could impact performance. [jsPerf](http://jsperf.com/ya-string-concat) & [Discussion](https://github.com/airbnb/javascript/issues/40).
@@ -536,6 +536,11 @@ Other Style Guides
     const errorMessage = 'This is a super long error that was thrown because ' +
       'of Batman. When you stop to think about how Batman had anything to do ' +
       'with this, you would get nowhere fast.';
+
+    // best
+    const errorMessage = `This is a super long error that was thrown because
+      of Batman. When you stop to think about how Batman had anything to do
+      with this, you would get nowhere fast.`;
     ```
 
   <a name="es6-template-literals"></a><a name="6.4"></a>

--- a/README.md
+++ b/README.md
@@ -871,19 +871,19 @@ Other Style Guides
     ```
 
   <a name="arrows--one-arg-parens"></a><a name="8.4"></a>
-  - [8.4](#arrows--one-arg-parens) If your function takes a single argument and doesn’t use braces, omit the parentheses. Otherwise, always include parentheses around arguments. eslint: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html) jscs:  [`disallowParenthesesAroundArrowParam`](http://jscs.info/rule/disallowParenthesesAroundArrowParam)
+  - [8.4](#arrows--one-arg-parens) Always include parentheses around arguments, even when there's only one argument. eslint: [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens.html) "always" option.
 
-    > Why? Less visual clutter.
+    > Why? Clarity around function arguments.
 
     ```js
     // bad
-    [1, 2, 3].map((x) => x * x);
-
-    // good
     [1, 2, 3].map(x => x * x);
 
     // good
-    [1, 2, 3].map(number => (
+    [1, 2, 3].map((x) => x * x);
+
+    // good
+    [1, 2, 3].map((number) => (
       `A long string with the ${number}. It’s so long that we’ve broken it ` +
       'over multiple lines!'
     ));
@@ -1109,7 +1109,7 @@ Other Style Guides
     ```
 
   <a name="modules--no-wildcard"></a><a name="10.2"></a>
-  - [10.2](#modules--no-wildcard) Do not use wildcard imports.
+  - [10.2](#modules--no-wildcard) Do not use wildcard imports, unless you're exporting actions or selectors in Reudx.
 
     > Why? This makes sure you have a single default export.
 
@@ -1202,6 +1202,25 @@ Other Style Guides
     import bar from 'bar';
 
     foo.init();
+    ```
+  <a name="modules--imports-order"></a>
+  - [10.7](#modules--imports-order) Import React and PropTypes first, followed by third-party libraries (e.g. material components), followed by top-level global components, followed by route and directory-specific components. Import styles last. Within each section, alphabetize imports. Include a space between outside imports and Newsela-specific imports.
+    > Why? For consistency and ease of finding import statements.
+
+    ```javascript
+    // bad
+    import React from 'react';
+    import styles from './styles.scss';
+    import Classroom from './components/Classroom';
+    import FlatButton from 'material-ui/FlatButton';
+
+    // good
+    import React from 'react';
+    import FlatButton from 'material-ui/FlatButton';
+
+    import Classroom from './components/Classroom';
+    import styles from './styles.scss';
+
     ```
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
This includes things like:

1. Not allowing spaces between curly braces
2. Newsela-specific import order
3. Using `_.size` and lodash methods in general over `.length` and inbuilt JavaScript methods.
4. A caveat for wildcard exports for Redux.