### PR TITLE
[eslint config][base][minor] add array-*-newline regarding to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ Other Style Guides
 
 **[⬆ back to top](#table-of-contents)**
 
-<a name="arrays--bracket-newline"></a>
-  - [4.6](#arrays--bracket-newline) Use line breaks after open and before close array brackets if an array has multiple lines
+<a name="arrays--newline"></a>
+  - [4.6](#arrays--newline) Use line breaks after open and before close array brackets and between elements if an array has multiple lines
 
   ```javascript
   // bad

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -3,6 +3,12 @@ module.exports = {
     // enforce spacing inside array brackets
     'array-bracket-spacing': ['error', 'never'],
 
+    // enforce line breaks after opening and before closing array brackets
+    'array-bracket-newline': ['error', { multiline: true }],
+
+    // enforce line breaks between elements when multiline
+    'array-element-newline': ['error', { multiline: true }],
+
     // enforce spacing inside single-line blocks
     // http://eslint.org/docs/rules/block-spacing
     'block-spacing': ['error', 'always'],


### PR DESCRIPTION
Follow PR of #1339. There are now 2 rules `array-bracket-newline` and `array-element-newline` which satisfies together the rule [4.6](https://github.com/airbnb/javascript#arrays--bracket-newline).

These rules are available since Eslint v4.0.0, so this PR should wait until Eslint v4 is supported by this styleguide (ref #1447).