### PR TITLE
Upgrade jsx-a11y to 6.0.2, enable more jsx-a11y rules

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -57,7 +57,7 @@
     "eslint": "^4.6.0",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.3.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "eslint": "^4.6.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.3.0"
   },

--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -13,7 +13,7 @@ module.exports = {
   rules: {
     // Enforce that anchors have content
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
-    'jsx-a11y/anchor-has-content': ['error', { components: [''] }],
+    'jsx-a11y/anchor-has-content': ['error', { components: [] }],
 
     // Require ARIA roles to be valid and non-abstract
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
@@ -31,10 +31,6 @@ module.exports = {
     // properties do not have those attributes.
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
     'jsx-a11y/aria-unsupported-elements': 'error',
-
-    // disallow href "#"
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash.md
-    'jsx-a11y/href-no-hash': ['error', { components: ['a'] }],
 
     // Enforce that all elements that require alternative text have meaningful information
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
@@ -55,9 +51,8 @@ module.exports = {
     'jsx-a11y/label-has-for': ['error', { components: ['label'] }],
 
     // require that mouseover/out come with focus/blur, for keyboard-only users
-    // TODO: evaluate
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
-    'jsx-a11y/mouse-events-have-key-events': 'off',
+    'jsx-a11y/mouse-events-have-key-events': 'error',
 
     // Prevent use of `accessKey`
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
@@ -109,8 +104,7 @@ module.exports = {
 
     // require onClick be accompanied by onKeyUp/onKeyDown/onKeyPress
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
-    // TODO: enable?
-    'jsx-a11y/click-events-have-key-events': 'off',
+    'jsx-a11y/click-events-have-key-events': 'error',
 
     // Enforce that DOM elements without semantic behavior not have interaction handlers
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
@@ -191,8 +185,7 @@ module.exports = {
 
     // ensure <a> tags are valid
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/0745af376cdc8686d85a361ce36952b1fb1ccf6e/docs/rules/anchor-is-valid.md
-    // TODO: enable, semver-major
-    'jsx-a11y/anchor-is-valid': ['off', {
+    'jsx-a11y/anchor-is-valid': ['error', {
       components: ['Link'],
       specialLink: [],
       aspects: ['noHref', 'invalidHref', 'preferButton'],


### PR DESCRIPTION
Upgrades eslint-plugin-jsx-a11y from 5 to 6, and enables more a11y related rules