### PR TITLE
Updated README, deleted an extra 'back to top'

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,8 +417,6 @@ Other Style Guides
     });
     ```
 
-**[⬆ back to top](#table-of-contents)**
-
 <a name="arrays--bracket-newline"></a>
   - [4.6](#arrays--bracket-newline) Use line breaks after open and before close array brackets if an array has multiple lines
 


### PR DESCRIPTION
In the README, there was an extra 'back to top' link in between sections 4.5 and 4.6 in the 'Arrays' section.