### PR TITLE
[eslint config] Improve Gruntfile glob pattern

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -82,7 +82,7 @@ module.exports = {
         '**/rollup.config.*.js', // rollup config
         '**/gulpfile.js', // gulp config
         '**/gulpfile.*.js', // gulp config
-        '**/Gruntfile', // grunt config
+        '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.*.js', // protractor config
       ],
       optionalDependencies: false,


### PR DESCRIPTION
To cover `Gruntfile`, `Gruntfile.js` and `Gruntfile.coffee` instead of just `Gruntfile`.