### PR TITLE
Add no-param-reassign exception for AVA test contexts.

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -179,6 +179,7 @@ module.exports = {
         'res', // for Express responses
         'response', // for Express responses
         '$scope', // for Angular 1 scopes
+        't', // for AVA test contexts
       ]
     }],
 


### PR DESCRIPTION
See https://github.com/avajs/ava/tree/a0d5b373a19e9eb0022ad2936b46a1608f11b53f#test-context

Essentially `before` and `after` hooks in AVA are able to share data with tests through the `t.context` object:

```js
test.beforeEach(t => {
	t.context.data = generateUniqueData();
});

test(t => {
	t.is(t.context.data + 'bar', 'foobar');
});
```