### PR TITLE
[inthewild] Removing "GitHub" from In The Wild reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3330,7 +3330,7 @@ Other Style Guides
   - **React**: [facebook.github.io/react/contributing/how-to-contribute.html#style-guide](https://facebook.github.io/react/contributing/how-to-contribute.html#style-guide)
   - **REI**: [reidev/js-style-guide](https://github.com/rei/code-style-guides/blob/master/docs/javascript.md)
   - **Ripple**: [ripple/javascript-style-guide](https://github.com/ripple/javascript-style-guide)
-  - **Sainsbury's Supermarkets**: [github/jsainsburyplc](https://github.com/jsainsburyplc)
+  - **Sainsbury's Supermarkets**: [jsainsburyplc](https://github.com/jsainsburyplc)
   - **SeekingAlpha**: [seekingalpha/javascript-style-guide](https://github.com/seekingalpha/javascript-style-guide)
   - **Shutterfly**: [shutterfly/javascript](https://github.com/shutterfly/javascript)
   - **Sourcetoad**: [sourcetoad/javascript](https://github.com/sourcetoad/javascript)


### PR DESCRIPTION
This removes the word "GitHub" from an In The Wild reference link, to prevent association with the main GitHub organisation.

Removed at the request of @1pete in #1500 comments.