### PR TITLE
Update yarn-specific install instructions

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -12,7 +12,7 @@ We export two ESLint configurations for your usage.
 
 Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
 
-If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-import`, or see below for npm instructions.
+If you use yarn, run `npm info "eslint-config-airbnb-base@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
 
 1. Install the correct versions of each package, which are listed by the command:
 

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -12,7 +12,7 @@ We export three ESLint configurations for your usage.
 
 Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
-If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y`, and see below for npm instructions.
+If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
 
 1. Install the correct versions of each package, which are listed by the command:
 


### PR DESCRIPTION
# Context
Attempts to clarify and address issue https://github.com/airbnb/javascript/issues/1508#issuecomment-319113807 to assist yarn users.

# What
New instructions recommend yarn users to list peer dependencies and then install each peer dependency with specified version.

# Why
Previous yarn instructions led users to install the latest version of each peer dependency which, in some cases, led to errors if the latest version of a peer dependency did not have rules that this package uses.