### PR TITLE
Add jest.config.js to import/no-extraneous-dependencies devDeps

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -76,6 +76,7 @@ module.exports = {
         'test.{js,jsx}', // repos with a single test file
         'test-*.{js,jsx}', // repos with multiple top-level test files
         '**/*.{test,spec}.{js,jsx}', // tests where the extension denotes that it is a test
+        '**/jest.config.js', // jest config
         '**/webpack.config.js', // webpack config
         '**/webpack.config.*.js', // webpack config
         '**/rollup.config.js', // rollup config


### PR DESCRIPTION
Similar to https://github.com/airbnb/javascript/issues/1168

This PR adds jest.config.js to the array of files that looks at `devDependencies` for its dependencies instead