### PR TITLE
Fix Arrow Functions 8.2 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,7 +921,7 @@ Other Style Guides
     // bad
     [1, 2, 3].map(number => {
       const nextNumber = number + 1;
-      `A string containing the ${nextNumber}.`;
+      return `A string containing the ${nextNumber}.`;
     });
 
     // good


### PR DESCRIPTION
Example 8.2 is failed by "no-unused-expressions" rule. It must be failed only by "arrow-parens" rule.