### PR TITLE
Update section on naming conventions for acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -2928,11 +2928,16 @@ Other Style Guides
       // ...
     ];
 
+    // also good
+    const httpRequests = [
+      // ...
+    ];
+
     // best
     import TextMessageContainer from './containers/TextMessageContainer';
 
     // best
-    const Requests = [
+    const requests = [
       // ...
     ];
     ```


### PR DESCRIPTION
This chapter on naming conventions tells that we should capitalize an acronym, like `HTTPRequests`, or drop the acronym part from the variable name. However, in the latter case it should actually be `requests`, not `Requests`, since it's a name for an array, not a constructor. Sorry if I get this wrong.