### PR TITLE
Support Protractor config files in import/no-extraneous-dependencies

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -84,6 +84,7 @@ module.exports = {
         '**/gulpfile.js', // gulp config
         '**/gulpfile.*.js', // gulp config
         '**/Gruntfile{,.js}', // grunt config
+        '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
       ],
       optionalDependencies: false,


### PR DESCRIPTION
This completes #1456 and allows for matching `protractor.conf.js` file (the basic one not the extended ones, i.e `protractor.conf.*.js`.