### PR TITLE
Update "eslint-plugin-jsx-a11y": "^6.0.2"

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -57,7 +57,7 @@
     "eslint": "^3.19.0 || ^4.5.0",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.3.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",


### PR DESCRIPTION
```bash
$ npm outdated
Package                 Current  Wanted  Latest  Location
eslint-plugin-jsx-a11y    5.1.1   5.1.1   6.0.2  React-Backend-Client
```

But, after updating package.json and running `npm install`:

    npm WARN eslint-config-airbnb@15.1.0 requires a peer of eslint-plugin-jsx-a11y@^5.1.1 but none was installed.