### PR TITLE
Removing functions from trailing comma rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2590,7 +2590,14 @@ Other Style Guides
       'Batman',
       'Superman',
     ];
+    ```
 
+  <a name="commas--dangling-in-function"></a><a name="20.3"></a>
+  - [20.3](#commas--dangling-in-function) Avoid trailing commas in function calls and declarations.
+
+    > Why? This causes syntax errors when executing.
+
+    ```javascript
     // bad
     function createHero(
       firstName,
@@ -2609,16 +2616,6 @@ Other Style Guides
       // does nothing
     }
 
-    // good (note that a comma must not appear after a "rest" element)
-    function createHero(
-      firstName,
-      lastName,
-      inventorOf,
-      ...heroArgs
-    ) {
-      // does nothing
-    }
-
     // bad
     createHero(
       firstName,
@@ -2631,14 +2628,6 @@ Other Style Guides
       firstName,
       lastName,
       inventorOf
-    );
-
-    // good (note that a comma must not appear after a "rest" element)
-    createHero(
-      firstName,
-      lastName,
-      inventorOf,
-      ...heroArgs
     );
     ```
 

--- a/README.md
+++ b/README.md
@@ -2595,7 +2595,7 @@ Other Style Guides
     function createHero(
       firstName,
       lastName,
-      inventorOf
+      inventorOf,
     ) {
       // does nothing
     }
@@ -2604,7 +2604,7 @@ Other Style Guides
     function createHero(
       firstName,
       lastName,
-      inventorOf,
+      inventorOf
     ) {
       // does nothing
     }
@@ -2623,14 +2623,14 @@ Other Style Guides
     createHero(
       firstName,
       lastName,
-      inventorOf
+      inventorOf,
     );
 
     // good
     createHero(
       firstName,
       lastName,
-      inventorOf,
+      inventorOf
     );
 
     // good (note that a comma must not appear after a "rest" element)

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -44,7 +44,7 @@ module.exports = {
       objects: 'always-multiline',
       imports: 'always-multiline',
       exports: 'always-multiline',
-      functions: 'always-multiline',
+      functions: 'never',
     }],
 
     // enforce spacing before and after comma


### PR DESCRIPTION
As per https://github.com/airbnb/javascript/issues/951

This isn't standard syntax in JavaScript and results in 'Syntax Errors' in the event of a trailing comma in a function call.