### PR TITLE
Fix a missing return statement in 8.2 rule's example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ Other Style Guides
 
     // good
     foo(() => {
-      bool = true;
+      return bool = true;
     });
     ```
 


### PR DESCRIPTION
Nothing much to discuss, just a simple fix on [8.2](https://github.com/airbnb/javascript#arrows--implicit-return) last example.