### PR TITLE
amend `jsx-a11y/label-has-for` option

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -48,7 +48,7 @@ module.exports = {
 
     // require that JSX labels use "htmlFor"
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-    'jsx-a11y/label-has-for': ['error', { components: ['label'] }],
+    'jsx-a11y/label-has-for': ['error', { components: ['label'], allowChildren: true }],
 
     // require that mouseover/out come with focus/blur, for keyboard-only users
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md


### PR DESCRIPTION
`jsx-a11y` introduced a new option `allowChildren` to rule `label-has-for` which default to `false` which doesn't allow label tag to have text in it e.g.
```jsx
<label htmlFor="username">Username</label>
```
this pr is intended to allow such style

[rule reference](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md)