### PR TITLE
Do not prefer destructuring for object assignment expression

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/es6.js
+++ b/packages/eslint-config-airbnb-base/rules/es6.js
@@ -118,7 +118,7 @@ module.exports = {
       },
       AssignmentExpression: {
         array: true,
-        object: true,
+        object: false,
       },
     }, {
       enforceForRenamedProperties: false,


### PR DESCRIPTION
```js
let param = 'default value';

if (object)
  param = object.param; // <= prefer-destructuring
}

// ...
```
I think that `param = object.param;` is better than `({ param } = object);` because it is easier to read and tedious to write brackets by hand.

MDN: [Destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)