### PR TITLE
Support unused vars

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -36,7 +36,7 @@ module.exports = {
     'no-undefined': 'off',
 
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
+    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true, argsIgnorePattern: '^_' }],
 
     // disallow use of variables before they are defined
     'no-use-before-define': ['error', { functions: true, classes: true, variables: true }],

--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -36,7 +36,9 @@ module.exports = {
     'no-undefined': 'off',
 
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true, argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      vars: 'all', args: 'after-used', ignoreRestSiblings: true, argsIgnorePattern: '^_'
+    }],
 
     // disallow use of variables before they are defined
     'no-use-before-define': ['error', { functions: true, classes: true, variables: true }],


### PR DESCRIPTION
Sometimes, I will have the following code:
```javascript
const express = require('express');

const router = express.Router();
router.get('/', (req, res, next) => {
  res.render('index', { title: 'Express' });
});
```
Currently, `next` is not used, so I want to support it like this:

```javascript
const express = require('express');

const router = express.Router();
router.get('/', (req, res, _) => {
  res.render('index', { title: 'Express' });
});
```
And underscore is natively for unused variable for programming language like Swift.
```swift
func f(p :String, _ :String) {
       // ...
}
```

I think that `_` is a good choice.