### PR TITLE
Enforce operator at the beginning of line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2000,7 +2000,7 @@ Other Style Guides
   <a name="control-statements"></a>
   - [17.1](#control-statements) In case your control statement (`if`, `while` etc.) gets too long or exceeds the maximum line length, each (grouped) condition could be put into a new line. The logical operator should begin the line.
 
-  > Why? Having operators at the beginning of the line keeps the operators aligned and follows a pattern similar to method chaining. This also improves readability by making it easier to visually follow complex logic.
+  > Why? Requiring operators at the beginning of the line keeps the operators aligned and follows a pattern similar to method chaining. This also improves readability by making it easier to visually follow complex logic.
 
     ```javascript
     // bad


### PR DESCRIPTION
Enables [operator-linebreak](https://eslint.org/docs/rules/operator-linebreak) rule with the "before" option in base eslint style config. This requires that operators be placed at the start of the line in a mulitline statement. 

```js
/* 
* Permitted Statements
*/

answer = everything ? 42  : foo;

if   (foo === 123 || bar === "abc") {
  thing1();
}

if (
  (foo === 123 || bar === "abc")
  && doesItLookGoodWhenItBecomesThatLong()
  && isThisReallyHappening()
) {
  thing1();
}

answer = everything
  ? 42
  : foo;
```
```js
/* 
* Invalid Statements
*/

if (
  (foo === 123 || bar === "abc") &&
  doesItLookGoodWhenItBecomesThatLong() &&
  isThisReallyHappening()
) {
  thing1();
}

answer = everything ?
  42 :
  foo;
```