### PR TITLE
Fixes readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2000,7 +2000,7 @@ Other Style Guides
   <a name="control-statements"></a>
   - [17.1](#control-statements) In case your control statement (`if`, `while` etc.) gets too long or exceeds the maximum line length, each (grouped) condition could be put into a new line. The logical operator should begin the line.
 
-  > Why? Requiring operators at the beginning of the line keeps the operators aligned and follows a pattern similar to method chaining. This also improves readability by making it easier to visually follow complex logic.
+    > Why? Requiring operators at the beginning of the line keeps the operators aligned and follows a pattern similar to method chaining. This also improves readability by making it easier to visually follow complex logic.
 
     ```javascript
     // bad


### PR DESCRIPTION
Accidentally broke the markdown formatting in the readme in this commit: 
https://github.com/airbnb/javascript/commit/2ab0e618582f5b64e406fe81fb5c9540b3be9824
Screenshot of broken Control Statements Section: 
![screen shot 2017-10-18 at 2 28 38 pm](https://user-images.githubusercontent.com/7876997/31743820-6bf4ca6c-b411-11e7-8f2e-346221006cb3.png)

Screenshot of fixed Control Statements section: 
![screen shot 2017-10-18 at 2 30 42 pm](https://user-images.githubusercontent.com/7876997/31743848-812fe376-b411-11e7-928e-0b32eef1009b.png)
