### PR TITLE
Fix markdown style breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,8 +647,8 @@ Other Style Guides
     };
 
     // good
-    //  lexical name distinguished from the variable-referenced invocation(s)
-    const short = function longUniqueMoreDescriptiveLexicalFoo() {
+    // lexical name distinguished from the variable-referenced invocation(s)
+    const short = function longUniqueMoreDescriptiveLexicalFoo() {
       // ...
     };
     ```


### PR DESCRIPTION
It came from the special characters "M-BM-":

``` bash
diff README.md README.md.new | cat -A
651c651$
<     const foo = function uniqueMoreDescriptiveLexicalFoo() {$
---$
>  M-BM-  M-BM- const short = function longUniqueMoreDescriptiveLexicalFoo() {$
```