### PR TITLE
Changes the eslint `no-mixed-operators` rule to only warn on mixing `**` and `%` with arithmetic operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1943,6 +1943,38 @@ Other Style Guides
     const baz = !c;
     ```
 
+  <a name="comparison--no-mixed-operators"></a><a name="15.8"></a>
+  - [15.7](#comparison--no-mixed-operators) Enclose operators in parentheses when they are mixed in a statement. When mixing arithmetic operators, do not mix `**` and `%` with themselves or with `+`, `-`, `*`, & `/`. eslint: [`no-mixed-operators`](http://eslint.org/docs/rules/no-mixed-operators.html)
+
+    > Why? This improves readability and clarifies the developer’s intention.
+
+    ```javascript
+    // bad
+    const foo = a && b < 0 || c > 0 || d + 1 === 0;
+
+    // bad
+    const bar = a ** b - 5 % d;
+
+    // bad
+    if (a || b && c) {
+      return d;
+    }
+
+    // good
+    const foo = (a && b < 0) || c > 0 || (d + 1 === 0);
+
+    // good
+    const bar = (a ** b) - (5 % d);
+
+    // good
+    if ((a || b) && c) {
+      return d;
+    }
+
+    // good
+    const bar = a + b / c * d;
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Blocks

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -254,8 +254,18 @@ module.exports = {
     // disallow un-paren'd mixes of different operators
     // http://eslint.org/docs/rules/no-mixed-operators
     'no-mixed-operators': ['error', {
+      // the list of arthmetic groups disallows mixing `%` and `**`
+      // with other arithmetic operators.
       groups: [
-        ['+', '-', '*', '/', '%', '**'],
+        ['%', '**'],
+        ['%', '+'],
+        ['%', '-'],
+        ['%', '*'],
+        ['%', '/'],
+        ['**', '+'],
+        ['**', '-'],
+        ['**', '*'],
+        ['**', '/'],
         ['&', '|', '^', '~', '<<', '>>', '>>>'],
         ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
         ['&&', '||'],


### PR DESCRIPTION
Changes the eslint `no-mixed-operators` rule to no longer warn on mixing common arithmetic operators unless they are mixed with `**` or`%`.

(Related Comment: https://github.com/airbnb/javascript/issues/1071#issuecomment-337913745)

**Guide Description:**

Enclose operators in parentheses when they are mixed in a statement. When mixing arithmetic operators, do not mix `**` and `%` with themselves or with `+`, `-`, `*`, & `/`. eslint: [`no-mixed-operators`](http://eslint.org/docs/rules/no-mixed-operators.html)

> Why? This improves readability and clarifies the developer’s intention.

```javascript
    // bad
    const foo = a && b < 0 || c > 0 || d + 1 === 0;

    // bad
    const bar = a ** b - 5 % d;

    // bad
    if (a || b && c) {
      return d;
    }

    // good
    const foo = (a && b < 0) || c > 0 || (d + 1 === 0);

    // good
    const bar = (a ** b) - (5 % d);

    // good
    if ((a || b) && c) {
      return d;
    }

    // good
    const bar = a + b / c * d;
```