### PR TITLE
Enables eslint rule: nonblock-statement-body-position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,7 +1981,7 @@ Other Style Guides
 ## Blocks
 
   <a name="blocks--braces"></a><a name="16.1"></a>
-  - [16.1](#blocks--braces) Use braces with all multi-line blocks.
+  - [16.1](#blocks--braces) Use braces with all multi-line blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
 
     ```javascript
     // bad

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -354,7 +354,7 @@ module.exports = {
 
     // enforce the location of single-line statements
     // http://eslint.org/docs/rules/nonblock-statement-body-position
-    'nonblock-statement-body-position': 'off',
+    'nonblock-statement-body-position': ['error', 'beside', { overrides: {} }],
 
     // require padding inside curly braces
     'object-curly-spacing': ['error', 'always'],


### PR DESCRIPTION
Enables [nonblock-statement-body-position](https://eslint.org/docs/rules/nonblock-statement-body-position) eslint rule and adds the link to the related guide section.