### PR TITLE
Added anti-pattern example for Props Naming rule, changed className props in examples

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -400,7 +400,7 @@
     ```jsx
     // bad
     render() {
-      return <MyComponent className="long body" foo="bar">
+      return <MyComponent variant="long body" foo="bar">
                <MyChild />
              </MyComponent>;
     }
@@ -408,7 +408,7 @@
     // good
     render() {
       return (
-        <MyComponent className="long body" foo="bar">
+        <MyComponent variant="long body" foo="bar">
           <MyChild />
         </MyComponent>
       );
@@ -427,10 +427,10 @@
 
     ```jsx
     // bad
-    <Foo className="stuff"></Foo>
+    <Foo variant="stuff"></Foo>
 
     // good
-    <Foo className="stuff" />
+    <Foo variant="stuff" />
     ```
 
   - If your component has multi-line properties, close its tag on a new line. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)

--- a/react/README.md
+++ b/react/README.md
@@ -143,6 +143,9 @@
     // bad
     <MyComponent style="fancy" />
 
+    // bad
+    <MyComponent className="fancy" />
+
     // good
     <MyComponent variant="fancy" />
     ```


### PR DESCRIPTION
- Added anti-pattern example for **Props Naming** rule with using `className `
- To be consistent with **Props Naming** rule changed `className `to `variant` props in others examples