### PR TITLE
Fix confusing method name in Classes & Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,8 +1066,8 @@ Other Style Guides
       this.queue = [...contents];
     }
     Queue.prototype.pop = function () {
-      const value = this.queue[0];
-      this.queue.splice(0, 1);
+      const value = this.queue[this.queue.length - 1];
+      this.queue.splice(-1, 1);
       return value;
     };
 
@@ -1077,8 +1077,8 @@ Other Style Guides
         this.queue = [...contents];
       }
       pop() {
-        const value = this.queue[0];
-        this.queue.splice(0, 1);
+        const value = this.queue[this.queue.length - 1];
+        this.queue.splice(-1, 1);
         return value;
       }
     }
@@ -1097,13 +1097,13 @@ Other Style Guides
     }
     inherits(PeekableQueue, Queue);
     PeekableQueue.prototype.peek = function () {
-      return this.queue[0];
+      return this.queue[this.queue.length - 1];
     };
 
     // good
     class PeekableQueue extends Queue {
       peek() {
-        return this.queue[0];
+        return this.queue[this.queue.length - 1];
       }
     }
     ```


### PR DESCRIPTION
Why? The method in the current example is called `pop()` but it actually implements an [Array.prototype.shift()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift) method which is confusing for no good reason. It just does it on the wrong side of an array.

I understand the change clutters the example code a bit, but at least it's less confusing.

Another approach--probably a better one--would be to change the name of the method from `pop` to `dequeue` leaving the implementation as is. The `peek` name and implementation could be left as is too then.