### PR TITLE
Add .mjs extension support

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -13,11 +13,12 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.json']
+        extensions: ['.mjs', '.js', '.json']
       }
     },
     'import/extensions': [
       '.js',
+      '.mjs',
       '.jsx',
     ],
     'import/core-modules': [

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -134,6 +134,7 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
     'import/extensions': ['error', 'always', {
       js: 'never',
+      mjs: 'never',
       jsx: 'never',
     }],
 


### PR DESCRIPTION
Fixes #1634 following what I think was @ljharb's intent, as per [his comment here](https://github.com/airbnb/javascript/issues/1592).

- [x] Add `.mjs` to the list of supported extensions
- [x] Forbid `.mjs` extension from being specified

