### PR TITLE
Ambiguous 'good' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ Other Style Guides
     const h = function() {};
 
     // good
-    const x = function () {};
+    const x = () => {};
     const y = function a() {};
     ```
 

--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ Other Style Guides
     // good
     const x = () => {};
     const y = function a() {};
+    const z = function abc() {};
     ```
 
   <a name="functions--mutate-params"></a><a name="7.12"></a>


### PR DESCRIPTION
7.11 uses the 'bad' example from 7.1. Changed to arrow function to prevent ambiguity.