### PR TITLE
Add 'to' as a specialLink to the 'anchor-is-valid' a11y rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -187,7 +187,7 @@ module.exports = {
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/0745af376cdc8686d85a361ce36952b1fb1ccf6e/docs/rules/anchor-is-valid.md
     'jsx-a11y/anchor-is-valid': ['error', {
       components: ['Link'],
-      specialLink: [],
+      specialLink: ['to'],
       aspects: ['noHref', 'invalidHref', 'preferButton'],
     }],
   },


### PR DESCRIPTION
Support React Router's `<Link to="...">` attribute out of the box.

Fixes #1647.