### PR TITLE
Set import/extensions to ignorePackages

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -132,7 +132,7 @@ module.exports = {
 
     // Ensure consistent use of file extension within the import path
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    'import/extensions': ['error', 'always', {
+    'import/extensions': ['error', 'ignorePackages', {
       js: 'never',
       mjs: 'never',
       jsx: 'never',


### PR DESCRIPTION
This allows to import non-JavaScript files through the main export of a dependency's package.json.

The following would trigger an error before, but is fine with the new configuration:

```js
import 'roboto-fontface';
```