### PR TITLE
Disable prefer-destructuring for array AssignmentExpressions

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/es6.js
+++ b/packages/eslint-config-airbnb-base/rules/es6.js
@@ -119,7 +119,7 @@ module.exports = {
         object: true,
       },
       AssignmentExpression: {
-        array: true,
+        array: false,
         object: true,
       },
     }, {


### PR DESCRIPTION
For instance, the following code snippets were flagged as erroneous before this change:

```js
outputs[0] = inputs[0]; // "Fix": [outputs[0]] = inputs;
outputs[0] = inputs[100];
```