### PR TITLE
[fixes: #1678] Improves wording of no-mixed-operators recommendation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1945,7 +1945,7 @@ Other Style Guides
     ```
 
   <a name="comparison--no-mixed-operators"></a>
-  - [15.8](#comparison--no-mixed-operators) Enclose operators in parentheses when they are mixed in a statement. When mixing arithmetic operators, do not mix `**` and `%` with themselves or with `+`, `-`, `*`, & `/`. eslint: [`no-mixed-operators`](https://eslint.org/docs/rules/no-mixed-operators.html)
+  - [15.8](#comparison--no-mixed-operators) When mixing operators, enclose them in parentheses. The only exception is the standard arithmetic operators (`+`, `-`, `*`, & `/`) since their precedence is broadly understood. eslint: [`no-mixed-operators`](https://eslint.org/docs/rules/no-mixed-operators.html)
 
     > Why? This improves readability and clarifies the developer’s intention.
 


### PR DESCRIPTION
Fixes: #1678 

@erights pointed out in #1678  that the wording of the [no-mixed-operators](https://eslint.org/docs/rules/no-mixed-operators.html) recommendation contradicts the valid cases. 

This PR changes the recommendation to: 
> When mixing operators, enclose them in parentheses. The only exception is the standard arithmetic operators (`+`, `-`, `*`, & `/`) since their precedence is broadly understood.
