### PR TITLE
Use npx to use install-peerdeps without actually globally installing install-peerdeps.

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -20,7 +20,14 @@ If you use yarn, run `npm info "eslint-config-airbnb-base@latest" peerDependenci
   npm info "eslint-config-airbnb-base@latest" peerDependencies
   ```
 
-  Linux/OSX users can run
+  If using **npm 5+**, use this shortcut
+
+  ```sh
+  npx install-peerdeps --dev eslint-config-airbnb-base
+  ```
+
+  If using **npm < 5**, Linux/OSX users can run
+
   ```sh
   (
     export PKG=eslint-config-airbnb-base;
@@ -34,7 +41,7 @@ If you use yarn, run `npm info "eslint-config-airbnb-base@latest" peerDependenci
     npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
   ```
 
-  Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
+  If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
 
   ```sh
   npm install -g install-peerdeps

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -20,7 +20,13 @@ If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` t
   npm info "eslint-config-airbnb@latest" peerDependencies
   ```
 
-  Linux/OSX users can run
+  If using **npm 5+**, use this shortcut
+
+  ```sh
+  npx install-peerdeps --dev eslint-config-airbnb
+  ```
+
+  If using **npm < 5**, Linux/OSX users can run
 
   ```sh
   (
@@ -35,13 +41,12 @@ If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` t
   npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
   ```
 
-  Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
+  If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
 
   ```sh
   npm install -g install-peerdeps
   install-peerdeps --dev eslint-config-airbnb
   ```
-
   The cli will produce and run a command like:
 
   ```sh


### PR DESCRIPTION
As node v8 is in LTS, many people have upgraded it to. With node8, there comes an awesome utility `npx` which allows us to run cli tools without installing them. 