### PR TITLE
fix example to meet standard listingId v listingID

### DIFF
--- a/README.md
+++ b/README.md
@@ -3178,8 +3178,8 @@ Other Style Guides
 
     // ...
 
-    $(this).on('listingUpdated', (e, listingId) => {
-      // do something with listingId
+    $(this).on('listingUpdated', (e, listingID) => {
+      // do something with listingID
     });
     ```
 
@@ -3187,12 +3187,12 @@ Other Style Guides
 
     ```javascript
     // good
-    $(this).trigger('listingUpdated', { listingId: listing.id });
+    $(this).trigger('listingUpdated', { listingID: listing.id });
 
     // ...
 
     $(this).on('listingUpdated', (e, data) => {
-      // do something with data.listingId
+      // do something with data.listingID
     });
     ```
 


### PR DESCRIPTION
fixed code example to meet the standard. `listingId` changed to `listingID` 
See - Naming Conventions: Acronyms and initialisms should always be all capitalized, or all lowercased.