### PR TITLE
Add componentDidCatch to class-methods-use-this exceptMethods property

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -29,6 +29,7 @@ module.exports = {
         'componentWillUpdate',
         'componentDidUpdate',
         'componentWillUnmount',
+        'componentDidCatch',
       ],
     }],
 
@@ -363,7 +364,7 @@ module.exports = {
     },
     react: {
       pragma: 'React',
-      version: '15.0'
+      version: '16.0'
     },
     propWrapperFunctions: [
       'forbidExtraProps', // https://www.npmjs.com/package/airbnb-prop-types


### PR DESCRIPTION
Updating the `class-methods-use-this` rule's `exceptMethods` property to include `componentDidCatch`, also bumped the react pragma version property to 16.0. See #1703 for original issue.