### PR TITLE
Ignore JSX curly brace presence for props to improve CSS-in-JS support

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -353,7 +353,7 @@ module.exports = {
 
     // Enforce curly braces or disallow unnecessary curly braces in JSX props and/or children
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md
-    'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }]
+    'react/jsx-curly-brace-presence': ['error', { props: 'ignore', children: 'never' }]
   },
 
   settings: {


### PR DESCRIPTION
This fix should only be in place until a better solution is found. _(See https://github.com/yannickcr/eslint-plugin-react/issues/1592)_