### PR TITLE
Use `acc` as `reduce` accumulator instead of `memo` to make it valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,16 +404,16 @@ Other Style Guides
     // good
     [1, 2, 3].map(x => x + 1);
 
-    // bad - no returned value means `memo` becomes undefined after the first iteration
-    [[0, 1], [2, 3], [4, 5]].reduce((memo, item, index) => {
-      const flatten = memo.concat(item);
-      memo[index] = flatten;
+    // bad - no returned value means `acc` becomes undefined after the first iteration
+    [[0, 1], [2, 3], [4, 5]].reduce((acc, item, index) => {
+      const flatten = acc.concat(item);
+      acc[index] = flatten;
     });
 
     // good
-    [[0, 1], [2, 3], [4, 5]].reduce((memo, item, index) => {
-      const flatten = memo.concat(item);
-      memo[index] = flatten;
+    [[0, 1], [2, 3], [4, 5]].reduce((acc, item, index) => {
+      const flatten = acc.concat(item);
+      acc[index] = flatten;
       return flatten;
     });
 


### PR DESCRIPTION
In [this part of the `no-param-reassign` configuration](https://github.com/airbnb/javascript/blob/53b2d7d245ba4abefc0429bfda4a46f099b9ace5/packages/eslint-config-airbnb-base/rules/best-practices.js#L174-L175), `acc` is allowed to be mutated (rule [7.12](https://github.com/airbnb/javascript#functions--mutate-params), but `memo` is not.

This causes the [rule 4.6 example](https://github.com/airbnb/javascript#arrays--callback-return) in the README to actually be invalid.

**Alternative proposal: Add `memo` to the whitelist along with `acc`, as it is a very common accumulator variable name for `reduce`.**