### PR TITLE
Suggest using WeakMaps when hidden properties are needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2993,6 +2993,11 @@ Other Style Guides
 
     // good
     this.firstName = 'Panda';
+
+    // good, in environments where WeakMaps are available
+    // see https://kangax.github.io/compat-table/es6/#test-WeakMap
+    const firstNames = new WeakMap();
+    firstNames.set(this, 'Panda');
     ```
 
   <a name="naming--self-this"></a><a name="22.5"></a>


### PR DESCRIPTION
This updates the "trailing or leading underscores" guideline to suggest an better way to make properties hidden, as an alternative to just removing the underscore and making the property public.

This is motivated by a discussion with @ljharb today in the `eslint/eslint` Gitter channel.