### PR TITLE
Line breaks for multi-entry array

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,11 @@ Other Style Guides
     ];
 
     // good
-    const arr = [[0, 1], [2, 3], [4, 5]];
+    const arr = [
+      [0, 1], 
+      [2, 3], 
+      [4, 5],
+    ];
 
     const objectInArray = [
       {


### PR DESCRIPTION
Description states, "Use line breaks after open and before close array brackets if an array has multiple lines," which would imply the form reflected in the edit. If the intention was actually to list the array as 'const arr = [[0, 1], [2, 3], [4, 5]];' a caveat should be added to 4.7 description, since it doesn't involve a line break after the opening or before the closing brackets.