### PR TITLE
Use single quotes for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2162,7 +2162,7 @@ Other Style Guides
 
     // good
     if (
-      (foo === 123 || bar === "abc")
+      (foo === 123 || bar === 'abc')
       && doesItLookGoodWhenItBecomesThatLong()
       && isThisReallyHappening()
     ) {


### PR DESCRIPTION
The other examples in the same section already use single quotes, so let's have the last culprit adhere to the standards.