### PR TITLE
Adds eslint config extends with only whitespace rules enabled

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -84,6 +84,10 @@ Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
 
 See [Airbnb's overarching ESLint config](https://npmjs.com/eslint-config-airbnb), [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript), and the [ESlint config docs](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.
 
+### eslint-config-airbnb-base/whitespace
+
+This entry point that only warns on whitespace rules and sets all other rules to warnings. View the list of whitespace rules [here](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/whitespace.js).
+
 ## Improving this config
 
 Consider adding test cases if you're making complicated rules changes, like anything involving regexes. Perhaps in a distant future, we could use literate programming to structure our README as test cases for our .eslintrc?

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -66,6 +66,7 @@
     "node": ">= 4"
   },
   "dependencies": {
-    "eslint-restricted-globals": "^0.1.1"
+    "eslint-restricted-globals": "^0.1.1",
+    "object.entries": "^1.0.4"
   }
 }

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -1,0 +1,73 @@
+const baseConfig = require('.');
+const entries = require('object.entries');
+const { CLIEngine } = require('eslint');
+
+function onlyErrorOnRules(rulesToError, config) {
+  const errorsOnly = { ...config };
+  const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
+  const baseRules = cli.getConfigForFile('./').rules;
+
+  entries(baseRules).forEach(([key, value]) => {
+    if (rulesToError.indexOf(key) === -1) {
+      if (Array.isArray(value)) {
+        errorsOnly.rules[key] = ['warn'].concat(value.slice(1));
+      } else if (typeof value === 'number') {
+        errorsOnly.rules[key] = 1;
+      } else {
+        errorsOnly.rules[key] = 'warn';
+      }
+    }
+  });
+
+  return errorsOnly;
+}
+
+module.exports = onlyErrorOnRules([
+  'array-bracket-newline',
+  'array-bracket-spacing',
+  'array-element-newline',
+  'arrow-spacing',
+  'block-spacing',
+  'comma-spacing',
+  'computed-property-spacing',
+  'dot-location',
+  'eol-last',
+  'func-call-spacing',
+  'function-paren-newline',
+  'generator-star-spacing',
+  'implicit-arrow-linebreak',
+  'indent',
+  'key-spacing',
+  'keyword-spacing',
+  'line-comment-position',
+  'linebreak-style',
+  'multiline-ternary',
+  'newline-per-chained-call',
+  'no-irregular-whitespace',
+  'no-mixed-spaces-and-tabs',
+  'no-multi-spaces',
+  'no-regex-spaces',
+  'no-spaced-func',
+  'no-trailing-spaces',
+  'no-whitespace-before-property',
+  'nonblock-statement-body-position',
+  'object-curly-newline',
+  'object-curly-spacing',
+  'object-property-newline',
+  'one-var-declaration-per-line',
+  'operator-linebreak',
+  'padded-blocks',
+  'padding-line-between-statements',
+  'rest-spread-spacing',
+  'semi-spacing',
+  'semi-style',
+  'space-before-blocks',
+  'space-before-function-paren',
+  'space-in-parens',
+  'space-infix-ops',
+  'space-unary-ops',
+  'spaced-comment',
+  'switch-colon-spacing',
+  'template-tag-spacing',
+  'import/newline-after-import',
+], baseConfig);

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -55,6 +55,10 @@ If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` t
 
 2. Add `"extends": "airbnb"` to your .eslintrc
 
+### eslint-config-airbnb/whitespace
+
+This entry point that only warns on whitespace rules and sets all other rules to warnings. View the list of whitespace rules [here](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/whitespace.js).
+
 ### eslint-config-airbnb/base
 
 This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -48,7 +48,8 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "dependencies": {
-    "eslint-config-airbnb-base": "^12.1.0"
+    "eslint-config-airbnb-base": "^12.1.0",
+    "object.entries": "^1.0.4"
   },
   "devDependencies": {
     "babel-preset-airbnb": "^2.4.0",

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -1,0 +1,87 @@
+const baseConfig = require('.');
+const entries = require('object.entries');
+const { CLIEngine } = require('eslint');
+
+function onlyErrorOnRules(rulesToError, config) {
+  const errorsOnly = { ...config };
+  const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
+  const baseRules = cli.getConfigForFile('./').rules;
+
+  entries(baseRules).forEach(([key, value]) => {
+    if (rulesToError.indexOf(key) === -1) {
+      if (Array.isArray(value)) {
+        errorsOnly.rules[key] = ['warn'].concat(value.slice(1));
+      } else if (typeof value === 'number') {
+        errorsOnly.rules[key] = 1;
+      } else {
+        errorsOnly.rules[key] = 'warn';
+      }
+    }
+  });
+
+  return errorsOnly;
+}
+
+module.exports = onlyErrorOnRules([
+  'array-bracket-newline',
+  'array-bracket-spacing',
+  'array-element-newline',
+  'arrow-spacing',
+  'block-spacing',
+  'comma-spacing',
+  'computed-property-spacing',
+  'dot-location',
+  'eol-last',
+  'func-call-spacing',
+  'function-paren-newline',
+  'generator-star-spacing',
+  'implicit-arrow-linebreak',
+  'indent',
+  'key-spacing',
+  'keyword-spacing',
+  'line-comment-position',
+  'linebreak-style',
+  'multiline-ternary',
+  'newline-per-chained-call',
+  'no-irregular-whitespace',
+  'no-mixed-spaces-and-tabs',
+  'no-multi-spaces',
+  'no-regex-spaces',
+  'no-spaced-func',
+  'no-trailing-spaces',
+  'no-whitespace-before-property',
+  'nonblock-statement-body-position',
+  'object-curly-newline',
+  'object-curly-spacing',
+  'object-property-newline',
+  'one-var-declaration-per-line',
+  'operator-linebreak',
+  'padded-blocks',
+  'padding-line-between-statements',
+  'rest-spread-spacing',
+  'semi-spacing',
+  'semi-style',
+  'space-before-blocks',
+  'space-before-function-paren',
+  'space-in-parens',
+  'space-infix-ops',
+  'space-unary-ops',
+  'spaced-comment',
+  'switch-colon-spacing',
+  'template-tag-spacing',
+  'import/newline-after-import',
+  // eslint-plugin-react rules
+  'react/jsx-child-element-spacing',
+  'react/jsx-closing-bracket-location',
+  'react/jsx-closing-tag-location',
+  'react/jsx-curly-spacing',
+  'react/jsx-equals-spacing',
+  'react/jsx-first-prop-newline',
+  'react/jsx-indent',
+  'react/jsx-indent-props',
+  'react/jsx-max-props-per-line',
+  'react/jsx-one-expression-per-line',
+  'react/jsx-space-before-closing',
+  'react/jsx-tag-spacing',
+  'react/jsx-wrap-multilines',
+], baseConfig);


### PR DESCRIPTION
Adds a change to pull in the eslint config from the project root, turn off all rules except the whitespace rules explicitly listed in the array.

This list is hardcoded for now, if there are any that I'm missing please let me know: 
```jsx
[
  'array-bracket-newline',
  'array-bracket-spacing',
  'array-element-newline',
  'arrow-spacing',
  'block-spacing',
  'comma-spacing',
  'computed-property-spacing',
  'dot-location',
  'eol-last',
  'func-call-spacing',
  'function-paren-newline',
  'generator-star-spacing',
  'implicit-arrow-linebreak',
  'indent',
  'key-spacing',
  'keyword-spacing',
  'line-comment-position',
  'linebreak-style',
  'multiline-ternary',
  'newline-per-chained-call',
  'no-irregular-whitespace',
  'no-mixed-spaces-and-tabs',
  'no-multi-spaces',
  'no-regex-spaces',
  'no-spaced-func',
  'no-trailing-spaces',
  'no-whitespace-before-property',
  'nonblock-statement-body-position',
  'object-curly-newline',
  'object-curly-spacing',
  'object-property-newline',
  'one-var-declaration-per-line',
  'operator-linebreak',
  'padded-blocks',
  'padding-line-between-statements',
  'rest-spread-spacing',
  'semi-spacing',
  'semi-style',
  'space-before-blocks',
  'space-before-function-paren',
  'space-in-parens',
  'space-infix-ops',
  'space-unary-ops',
  'spaced-comment',
  'switch-colon-spacing',
  'template-tag-spacing',
  'import/newline-after-import',
]
```