### PR TITLE
Update object-curly-newline to match ESLint 4.18.0

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -383,7 +383,9 @@ module.exports = {
     // https://eslint.org/docs/rules/object-curly-newline
     'object-curly-newline': ['error', {
       ObjectExpression: { minProperties: 4, multiline: true, consistent: true },
-      ObjectPattern: { minProperties: 4, multiline: true, consistent: true }
+      ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
+      ImportDeclaration: { minProperties: 4, multiline: true, consistent: true },
+      ExportDeclaration: { minProperties: 4, multiline: true, consistent: true },
     }],
 
     // enforce "same line" or "multiple line" on object properties.


### PR DESCRIPTION
In ESLint 4.18.0 separate settings are introduced for imports and exports for the object-curly-newline rule.

Without this change, there is different behaviour when updating ESLint to this version.