### PR TITLE
avoid __mocks__ no-extraneous-dependencies check

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -74,6 +74,7 @@ module.exports = {
         'tests/**', // also common npm pattern
         'spec/**', // mocha, rspec-like pattern
         '**/__tests__/**', // jest pattern
+        '**/__mocks__/**', // jest pattern
         'test.{js,jsx}', // repos with a single test file
         'test-*.{js,jsx}', // repos with multiple top-level test files
         '**/*.{test,spec}.{js,jsx}', // tests where the extension denotes that it is a test


### PR DESCRIPTION
They should be considered as dev scripts.