### PR TITLE
fix: bad comment already had a space at the beginning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2267,7 +2267,7 @@ Other Style Guides
 
     ```javascript
     // bad
-    // is current tab
+    //is current tab
     const active = true;
 
     // good


### PR DESCRIPTION
For section 18.3 of the README, the example of a bad comment shouldn't have a space at the beginning.