### PR TITLE
Add StandardJS to "Other Style Guides" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3484,6 +3484,7 @@ Other Style Guides
   - [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml)
   - [jQuery Core Style Guidelines](https://contribute.jquery.org/style-guide/js/)
   - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)
+  - [StandardJS](https://standardjs.com)
 
 **Other Styles**
 


### PR DESCRIPTION
StandardJS is one of the top style guides, though like the Google and jQuery styles it's less popular than the airbnb style. 😀