### PR TITLE
doc: fix some nits in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ Other Style Guides
     };
     ```
 
+  <a name="whitespace--implicit-arrow-linebreak"></a>
   - [8.6](#whitespace--implicit-arrow-linebreak) Enforce the location of arrow function bodies with implicit returns. eslint: [`implicit-arrow-linebreak`](https://eslint.org/docs/rules/implicit-arrow-linebreak)
 
     ```javascript
@@ -2682,6 +2683,7 @@ Other Style Guides
       .fail(() => console.log('You have failed this city.'));
     ```
 
+  <a name="whitespace--block-spacing"></a>
   - [19.13](#whitespace--block-spacing) Require consistent spacing inside an open block token and the next token on the same line. This rule also enforces consistent spacing inside a close block token and previous token on the same line. eslint: [`block-spacing`](https://eslint.org/docs/rules/block-spacing)
 
     ```javascript
@@ -2694,6 +2696,7 @@ Other Style Guides
     if (foo) { bar = 0; }
     ```
 
+  <a name="whitespace--comma-spacing"></a>
   - [19.14](#whitespace--comma-spacing) Avoid spaces before commas and require a space after commas. eslint: [`comma-spacing`](https://eslint.org/docs/rules/comma-spacing)
 
     ```javascript
@@ -2706,7 +2709,8 @@ Other Style Guides
     var arr = [1, 2];
     ```
 
-  - [19.15](#whitespace--computed-property-spacing) Avoid spaces before commas and require a space after commas. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
+  <a name="whitespace--computed-property-spacing"></a>
+  - [19.15](#whitespace--computed-property-spacing) Enforce spacing inside of computed properties. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
 
     ```javascript
     // bad
@@ -2722,6 +2726,7 @@ Other Style Guides
     obj[foo[bar]]
     ```
 
+  <a name="whitespace--func-call-spacing"></a>
   - [19.16](#whitespace--func-call-spacing) Enforce spacing between functions and their invocations. eslint: [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing)
 
     ```javascript
@@ -2735,6 +2740,7 @@ Other Style Guides
     func();
     ```
 
+  <a name="whitespace--key-spacing"></a>
   - [19.17](#whitespace--key-spacing) Enforce spacing between keys and values in object literal properties. eslint: [`key-spacing`](https://eslint.org/docs/rules/key-spacing)
 
     ```javascript
@@ -2746,8 +2752,10 @@ Other Style Guides
     var obj = { "foo": 42 };
     ```
 
+  <a name="whitespace--no-trailing-spaces"></a>
   - [19.18](#whitespace--no-trailing-spaces) Avoid trailing spaces at the end of lines. eslint: [`no-trailing-spaces`](https://eslint.org/docs/rules/no-trailing-spaces)
 
+  <a name="whitespace--no-multiple-empty-lines"></a>
   - [19.19](#whitespace--no-multiple-empty-lines) Avoid multiple empty lines and only allow one newline at the end of files. eslint: [`no-multiple-empty-lines`](https://eslint.org/docs/rules/no-multiple-empty-lines)
 
     <!-- markdownlint-disable MD012 -->


### PR DESCRIPTION
This PR corrects some nits slipped in edf942eeb6bee3ae538e1484861ea0721fad4856

* Add missing anchors for section references.
* Correct a rule description.