### PR TITLE
Adjust eslint rule import/no-extraneous-dependencies for vue-cli

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -79,6 +79,7 @@ module.exports = {
         'test-*.{js,jsx}', // repos with multiple top-level test files
         '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
         '**/jest.config.js', // jest config
+        '**/vue.config.js', // vue-cli config
         '**/webpack.config.js', // webpack config
         '**/webpack.config.*.js', // webpack config
         '**/rollup.config.js', // rollup config


### PR DESCRIPTION
Allows the vue-cli config file `vue.config.js` to import `devDependencies` by
altering the rule `import/no-extraneous-dependencies`.