### PR TITLE
Fix broken aria roles link in React style guide README

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -307,7 +307,7 @@ This style guide is mostly based on the standards that are currently prevalent i
     <img src="hello.jpg" alt="Me waving hello" />
     ```
 
-  - Use only valid, non-abstract [ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions). eslint: [`jsx-a11y/aria-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md)
+  - Use only valid, non-abstract [ARIA roles](https://www.w3.org/TR/wai-aria/#usage_intro). eslint: [`jsx-a11y/aria-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md)
 
     ```jsx
     // bad - not an ARIA role


### PR DESCRIPTION
seemed like the link was broken/outdated, I updated it with what seems a good replacement