### PR TITLE
Add peer-version-check to CI step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ install:
   - 'if [ -n "${PACKAGE-}" ]; then cd "packages/${PACKAGE}"; fi'
   - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.9" ]; then nvm install --latest-npm 0.8 && npm install && nvm use "${TRAVIS_NODE_VERSION}"; else npm install; fi;'
   - 'if [ -n "${ESLINT}" ]; then npm install --no-save "eslint@${ESLINT}"; fi'
+before_script:
+  npx peer-version-check packages/eslint-config-airbnb/package.json
+  npx peer-version-check packages/eslint-config-airbnb-base/package.json
 script:
   - 'if [ -n "${PREPUBLISH-}" ]; then npm run pretravis && npm run prepublish && npm run posttravis; elif [ -n "${LINT-}" ]; then npm run lint; else npm run travis; fi'
 sudo: false

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -60,7 +60,7 @@
     "tape": "^4.9.0"
   },
   "peerDependencies": {
-    "eslint": "^4.19.1",
+    "eslint": "^4.19.2",
     "eslint-plugin-import": "^2.12.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "eslint": "^4.19.1",
-    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.8.2"
   },


### PR DESCRIPTION
I noticed that you're using the same workaround to deal with `peerDependencies` for development like we do by duplicating `peerDependencies` as `devDependencies`. 

Obviously duplicating is not the best solution, but it works. However there is a risk that they can get out of sync easily. To solve this issue, I wrote this CLI which checks if every peerDependency is defined as a devDependency with the same semver range.  Exits with code 1 and an error message if the check fails and 0 if not.

https://github.com/stefanbuck/peer-version-check

