### PR TITLE
Add DEV/CI scripts to no-extraneous-dependencies exception list

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -88,6 +88,7 @@ module.exports = {
         '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
+        'scripts/**', // DEV/CI scripts, not for production
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
Several of our projects have script files that are executed in our CI build, like for example to check the licenses of npm packages used. These are not used for production, and thus the dependencies used are devDependencies. The current rule settings report errors now for those imports. Right now there is only testing and build config stuff in the exception list, but other non-production scripts is also common to many projects. So that's the reason for this pull-request. If such scripts are put in a scripts folder, I think that is clear, but if there are other opinions about this, please share.