### PR TITLE
Add new methods introduced in react@16.3

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -23,13 +23,17 @@ module.exports = {
         'getDefaultProps',
         'getChildContext',
         'componentWillMount',
+        'UNSAFE_componentWillMount',
         'componentDidMount',
         'componentWillReceiveProps',
+        'UNSAFE_componentWillReceiveProps',
         'shouldComponentUpdate',
         'componentWillUpdate',
+        'UNSAFE_componentWillUpdate',
         'componentDidUpdate',
         'componentWillUnmount',
         'componentDidCatch',
+        'getSnapshotBeforeUpdate'
       ],
     }],
 


### PR DESCRIPTION
React have introduced new methods and marked few old methods as Legacy methods and adviced not to use in new code. I've added all that methods in this commit for eslint rules. 

Fixes #1805.