### PR TITLE
Use require.resolve to allow nested extend

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -7,8 +7,8 @@ module.exports = {
     sourceType: 'module'
   },
   plugins: [
-    'import'
-  ],
+    'eslint-plugin-import'
+  ].map(require.resolve),
 
   settings: {
     'import/resolver': {

--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -1,8 +1,8 @@
 module.exports = {
   plugins: [
-    'jsx-a11y',
-    'react'
-  ],
+    'eslint-plugin-jsx-a11y',
+    'eslint-plugin-react'
+  ].map(require.resolve),
 
   parserOptions: {
     ecmaFeatures: {

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: [
-    'react',
-  ],
+    'eslint-plugin-react',
+  ].map(require.resolve),
 
   parserOptions: {
     ecmaFeatures: {


### PR DESCRIPTION
Continues #582

If you will start to use config `{ extends: ["eslint-config-airbnb"] }` in the project `a` together with the following peer dependencies `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, then you will receive an error if you will try to extend this config in the project `b`:

/projects/a/.eslintrc Referenced from: /projects/b/.eslintrc
[Error] Failed to load plugin /projects/a/node_modules/eslint-plugin-jsx-a11y/lib/index.js: Cannot find module 'eslint-plugin-/projects/a/node_modules/eslint-plugin-jsx-a11y/lib/index.js' Referenced from: /projects/b/.eslintrc

This issue is probably actual for monorepos. For example it is not cool to install `import`, `jsx-a11y` and `react` plugins into `node_modules` folder of the each project. This change helps to avoid it.