### PR TITLE
Upgrade: markdownlint-cli@0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "markdownlint-cli": "^0.3.1"
+    "markdownlint-cli": "^0.10.0"
   }
 }


### PR DESCRIPTION
build failing somehow, but should not be related to the change.