### PR TITLE
Clarify wording for computed properties spacing rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2764,7 +2764,7 @@ Other Style Guides
     ```
 
   <a name="whitespace--computed-property-spacing"></a>
-  - [19.15](#whitespace--computed-property-spacing) Enforce spacing inside of computed properties. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
+  - [19.15](#whitespace--computed-property-spacing) Enforce spacing inside of computed property brackets. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
 
     ```javascript
     // bad


### PR DESCRIPTION
This PR aligns the wording with what's stated in the ESLint documentation:
>…
>"never" (default) disallows spaces **inside computed property brackets**

(https://eslint.org/docs/rules/computed-property-spacing#options)