### PR TITLE
Update to babel 7

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -53,8 +53,8 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "babel-preset-airbnb": "^2.5.3",
-    "babel-tape-runner": "^2.0.1",
+    "babel-preset-airbnb": "^3.0.1",
+    "babel-tape-runner": "^3.0.0",
     "editorconfig-tools": "^0.1.1",
     "eslint": "^4.19.1 || ^5.3.0",
     "eslint-find-rules": "^3.3.1",

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -59,8 +59,8 @@
     "object.entries": "^1.0.4"
   },
   "devDependencies": {
-    "babel-preset-airbnb": "^2.5.3",
-    "babel-tape-runner": "^2.0.1",
+    "babel-preset-airbnb": "^3.0.1",
+    "babel-tape-runner": "^3.0.0",
     "editorconfig-tools": "^0.1.1",
     "eslint": "^4.19.1 || ^5.3.0",
     "eslint-find-rules": "^3.3.1",


### PR DESCRIPTION
Not much to do here, just updating the dependencies should be enough. (Although I would drop use of [`babel-tape-runner`](https://github.com/wavded/babel-tape-runner) for `tape --require @babel/register`.)

With `babel` v7, we can also use `babel.config.js` to run all tests at the same time. If interested I can PR that as well.