### PR TITLE
[19.16] changed Enforce to avoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2781,7 +2781,7 @@ Other Style Guides
     ```
 
   <a name="whitespace--func-call-spacing"></a>
-  - [19.16](#whitespace--func-call-spacing) Enforce spacing between functions and their invocations. eslint: [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing)
+  - [19.16](#whitespace--func-call-spacing) Avoid spaces between functions and their invocations. eslint: [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing)
 
     ```javascript
     // bad


### PR DESCRIPTION
Good practice is to avoid spaces between functions and their invocations. But by mistake (I think so) you used the word Enforce instead of Avoid