### PR TITLE
jsx-a11y/label-has-associated-control: assert either not both

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -51,7 +51,7 @@ module.exports = {
     'jsx-a11y/label-has-for': ['error', {
       components: [],
       required: {
-        every: ['nesting', 'id'],
+        some: ['nesting', 'id'],
       },
       allowChildren: false,
     }],
@@ -62,7 +62,7 @@ module.exports = {
       labelComponents: [],
       labelAttributes: [],
       controlComponents: [],
-      assert: 'both',
+      assert: 'either',
       depth: 25
     }],
 


### PR DESCRIPTION
The current rules require an input within a label to be marked up with `id`/`htmlFor`. This seems bizarre and unnecessary.

That is, the following markup is perfectly accessible and the rules should reflect that:
```js
<label>
  <input type="checkbox" />
  Accept terms and conditions 
</label>
```

Similar examples are shown on the rule's readme doc. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md