### PR TITLE
Use correct github url for eslint-config-airbnb package

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/airbnb/javascript"
+    "url": "https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
When clicking the github link from the eslint-config-airbnb npm page, it should go to the github page for this specific package, not the parent repo