### PR TITLE
[eslint config] [base] [deps] Switch to confusing-browser-globals

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -71,7 +71,7 @@
     "node": ">= 4"
   },
   "dependencies": {
-    "eslint-restricted-globals": "^0.1.1",
+    "confusing-browser-globals": "^1.0.5",
     "object.assign": "^4.1.0",
     "object.entries": "^1.0.4"
   }

--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -1,4 +1,4 @@
-const restrictedGlobals = require('eslint-restricted-globals');
+const confusingBrowserGlobals = require('confusing-browser-globals');
 
 module.exports = {
   rules: {
@@ -16,7 +16,7 @@ module.exports = {
     'no-label-var': 'error',
 
     // disallow specific globals
-    'no-restricted-globals': ['error', 'isFinite', 'isNaN'].concat(restrictedGlobals),
+    'no-restricted-globals': ['error', 'isFinite', 'isNaN'].concat(confusingBrowserGlobals),
 
     // disallow declaration of variables already declared in the outer scope
     'no-shadow': 'error',


### PR DESCRIPTION
The `eslint-restricted-globals` package author created an equivalent package `confusing-browser-globals` that now resides within the create-react-app monorepo. In sidoshi/eslint-restricted-globals#2 @sidoshi suggested that we change eslint-config-airbnb-base to depend on the CRA package instead, in an effort to consolidate the two.

Currently the two global lists are identical, so this does not change the generated eslint config:
https://unpkg.com/eslint-restricted-globals@0.2.0/index.js
https://unpkg.com/confusing-browser-globals@1.0.5/index.js