### PR TITLE
Add markers to spaced-comment block for Flow types

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -498,7 +498,7 @@ module.exports = {
       },
       block: {
         exceptions: ['-', '+'],
-        markers: ['=', '!'], // space here to support sprockets directives
+        markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
         balanced: true,
       }
     }],


### PR DESCRIPTION
Tested in one of my projects - Flow allows a syntax for typing in comments, but these markers have to be added to not throw errors. Flow could do it with a space in between, but it seems like an easy enough style to allow, and a good one to follow.