### PR TITLE
[guide] [react] add note about deprecated lifecycles

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -627,8 +627,11 @@ We don’t recommend using indexes for keys if the order of items may change.
   1. optional `static` methods
   1. `constructor`
   1. `getChildContext`
+  1. `componentWillMount`
   1. `componentDidMount`
+  1. `componentWillReceiveProps`
   1. `shouldComponentUpdate`
+  1. `componentWillUpdate`
   1. `componentDidUpdate`
   1. `componentWillUnmount`
   1. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`
@@ -680,8 +683,11 @@ We don’t recommend using indexes for keys if the order of items may change.
   1. `getDefaultProps`
   1. `getInitialState`
   1. `getChildContext`
+  1. `componentWillMount`
   1. `componentDidMount`
+  1. `componentWillReceiveProps`
   1. `shouldComponentUpdate`
+  1. `componentWillUpdate`
   1. `componentDidUpdate`
   1. `componentWillUnmount`
   1. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`

--- a/react/README.md
+++ b/react/README.md
@@ -626,11 +626,8 @@ We don’t recommend using indexes for keys if the order of items may change.
   1. optional `static` methods
   1. `constructor`
   1. `getChildContext`
-  1. `componentWillMount`
   1. `componentDidMount`
-  1. `componentWillReceiveProps`
   1. `shouldComponentUpdate`
-  1. `componentWillUpdate`
   1. `componentDidUpdate`
   1. `componentWillUnmount`
   1. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`
@@ -682,11 +679,8 @@ We don’t recommend using indexes for keys if the order of items may change.
   1. `getDefaultProps`
   1. `getInitialState`
   1. `getChildContext`
-  1. `componentWillMount`
   1. `componentDidMount`
-  1. `componentWillReceiveProps`
   1. `shouldComponentUpdate`
-  1. `componentWillUpdate`
   1. `componentDidUpdate`
   1. `componentWillUnmount`
   1. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`

--- a/react/README.md
+++ b/react/README.md
@@ -21,6 +21,7 @@ This style guide is mostly based on the standards that are currently prevalent i
   1. [Methods](#methods)
   1. [Ordering](#ordering)
   1. [`isMounted`](#ismounted)
+  1. [Things to avoid](#thingstoavoid)
 
 ## Basic Rules
 
@@ -695,6 +696,15 @@ We don’t recommend using indexes for keys if the order of items may change.
   > Why? [`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and is on its way to being officially deprecated.
 
   [anti-pattern]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
+  
+## Things to avoid
+
+Using deprecated APIs will create bad legacy code. Hence it's good to know that which APIs have been deprecated.
+
+These Component lifecycles are been deprecated since React version 16.3+ :
+- componentWillMount
+- componentWillReceiveProps
+- componentWillUpdate
 
 ## Translation
 


### PR DESCRIPTION
There were still deprecated lifecycle being mentioned in two places. Thus by removing them, it will make clear sense of latest React API after 16.2.