### PR TITLE
Adjust lines-around-comment to enforce empty lines before comments

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -180,7 +180,13 @@ module.exports = {
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: false }],
 
     // enforces empty lines around comments
-    'lines-around-comment': 'off',
+    'lines-around-comment': ['error', {
+      beforeLineComment: true,
+      allowBlockStart: true,
+      allowObjectStart: true,
+      allowArrayStart: true,
+      allowClassStart: true,
+    }],
 
     // require or disallow newlines around directives
     // https://eslint.org/docs/rules/lines-around-directive


### PR DESCRIPTION
Enabling this rule only enforces what's been in the styleguide for a while already: https://github.com/airbnb/javascript#comments