### PR TITLE
Allow use of __REDUX_DEVTOOLS_EXTENSION_COMPOSE__

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -369,7 +369,7 @@ module.exports = {
     // disallow dangling underscores in identifiers
     // https://eslint.org/docs/rules/no-underscore-dangle
     'no-underscore-dangle': ['error', {
-      allow: ['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
+      allow: [],
       allowAfterThis: false,
       allowAfterSuper: false,
       enforceInMethodNames: true,

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -369,7 +369,7 @@ module.exports = {
     // disallow dangling underscores in identifiers
     // https://eslint.org/docs/rules/no-underscore-dangle
     'no-underscore-dangle': ['error', {
-      allow: [],
+      allow: ['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
       allowAfterThis: false,
       allowAfterSuper: false,
       enforceInMethodNames: true,

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -1,3 +1,8 @@
+const assign = require('object.assign');
+const baseStyleRules = require('eslint-config-airbnb-base/rules/style').rules;
+
+const dangleRules = baseStyleRules['no-underscore-dangle'];
+
 module.exports = {
   plugins: [
     'react',
@@ -12,6 +17,10 @@ module.exports = {
   // View link below for react rules documentation
   // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
   rules: {
+    'no-underscore-dangle': [dangleRules[0], assign({}, dangleRules[1], {
+      allow: dangleRules[1].allow.concat(['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__']),
+    })],
+
     // Specify whether double or single quotes should be used in JSX attributes
     // https://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': ['error', 'prefer-double'],


### PR DESCRIPTION
This style guide disallows the use of underscores in properties. However, the Redux browser extension requires the use of a variable named `__REDUX_DEVTOOLS_EXTENSION_COMPOSE__`. Since Redux is so popular with React, it makes sense to allow this.

This saves an `eslint-disable` comment in pretty much all of my React projects. I’m probably not the only one.