### PR TITLE
Add test setup file from cra to dev dependencies

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -89,6 +89,7 @@ module.exports = {
         '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
+        'src/setupTests.js', // create react app config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
Hi Guys (and Girls)! We have been using this configuration for years now, so thanks for that 😄 I would like to propose to add [the `setupTests.js` file from Create React App](https://facebook.github.io/create-react-app/docs/running-tests#src-setuptestsjs). Basically all dependencies in this exact file is used for testing. I'm not sure if this might be more relevant in the actual react eslint config, but I couldn't find this rule over there.

Hope it helps ❤️ 