### PR TITLE
Improve ESLint config setup instructions for Yarn

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -12,8 +12,6 @@ We export two ESLint configurations for your usage.
 
 Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
 
-If you use yarn, run `npm info "eslint-config-airbnb-base@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
-
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
@@ -25,6 +23,10 @@ If you use yarn, run `npm info "eslint-config-airbnb-base@latest" peerDependenci
   ```sh
   npx install-peerdeps --dev eslint-config-airbnb-base
   ```
+
+  If using **yarn**, you can also use the shortcut described above if you have npm 5+ installed on your machine, as the command will detect that you are using yarn and will act accordingly.
+  Otherwise, run `npm info "eslint-config-airbnb-base@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency.
+
 
   If using **npm < 5**, Linux/OSX users can run
 

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -12,8 +12,6 @@ We export three ESLint configurations for your usage.
 
 Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
-If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
-
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
@@ -25,6 +23,9 @@ If you use yarn, run `npm info "eslint-config-airbnb@latest" peerDependencies` t
   ```sh
   npx install-peerdeps --dev eslint-config-airbnb
   ```
+
+  If using **yarn**, you can also use the shortcut described above if you have npm 5+ installed on your machine, as the command will detect that you are using yarn and will act accordingly.
+  Otherwise, run `npm info "eslint-config-airbnb@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency.
 
   If using **npm < 5**, Linux/OSX users can run
 


### PR DESCRIPTION
It is now possible to use the `npx install-peerdeps` command when using Yarn, since it will detect that the user is using Yarn and will act accordingly:

![screenshot from 2019-02-07 11-54-56](https://user-images.githubusercontent.com/4053871/52428075-38242300-2acf-11e9-9e53-b3692fcb60bf.png)

Therefore, this pull request improves the setup instructions to mention that it is possible to use this shortcut while using Yarn as well.