### PR TITLE
fix example 4.7 for arrays method callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,13 +423,11 @@ Other Style Guides
     // bad - no returned value means `acc` becomes undefined after the first iteration
     [[0, 1], [2, 3], [4, 5]].reduce((acc, item, index) => {
       const flatten = acc.concat(item);
-      acc[index] = flatten;
     });
 
     // good
     [[0, 1], [2, 3], [4, 5]].reduce((acc, item, index) => {
       const flatten = acc.concat(item);
-      acc[index] = flatten;
       return flatten;
     });
 


### PR DESCRIPTION
This PR removes an unnecessary expression from the example. The line was part of the non-working example and should not be part of the best practice example.