### PR TITLE
[eslint config] [react] Add support for React Hooks

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -10,7 +10,7 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-airbnb
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -39,7 +39,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -51,10 +51,14 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
-2. Add `"extends": "airbnb"` to your .eslintrc
+2. Add `"extends": "airbnb"` to your `.eslintrc`
+
+### eslint-config/airbnb/hooks
+
+This entry point enables the linting rules for React hooks (requires v16.8+). To use, add `"extends": "airbnb/hooks"` to your `.eslintrc`
 
 ### eslint-config-airbnb/whitespace
 

--- a/packages/eslint-config-airbnb/hooks.js
+++ b/packages/eslint-config-airbnb/hooks.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: [
+    './rules/react-hooks.js',
+  ].map(require.resolve),
+  rules: {}
+};

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-hooks": "^1.7.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^1.1.2",
@@ -76,7 +77,8 @@
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.14.2"
+    "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-hooks": "^1.7.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb/rules/react-hooks.js
+++ b/packages/eslint-config-airbnb/rules/react-hooks.js
@@ -1,0 +1,21 @@
+module.exports = {
+  plugins: [
+    'react-hooks',
+  ],
+
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+
+  rules: {
+    // Enforce Rules of Hooks
+    // https://github.com/facebook/react/blob/c11015ff4f610ac2924d1fc6d569a17657a404fd/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+    'react-hooks/rules-of-hooks': 'error',
+
+    // Verify the list of the dependencies for Hooks like useEffect and similar
+    // https://github.com/facebook/react/blob/1204c789776cb01fbaf3e9f032e7e2ba85a44137/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+    'react-hooks/exhaustive-deps': 'error',
+  },
+};

--- a/packages/eslint-config-airbnb/test/requires.js
+++ b/packages/eslint-config-airbnb/test/requires.js
@@ -9,6 +9,7 @@ test('all entry points parse', (t) => {
   t.doesNotThrow(() => require('../base'), 'base does not throw');
   t.doesNotThrow(() => require('../legacy'), 'legacy does not throw');
   t.doesNotThrow(() => require('../whitespace'), 'whitespace does not throw');
+  t.doesNotThrow(() => require('../hooks'), 'hooks does not throw');
 
   t.end();
 });


### PR DESCRIPTION
Fixes #1944 

Looks like everyone (via #1944) is in favor of adding support for React Hooks!

`eslint-plugin-react-hooks` is stable now and could be included in `eslint-config-airbnb`.