### PR TITLE
8.2 expression with side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,7 @@ Other Style Guides
     // good
     foo(() => {
       bool = true;
+      return bool;
     });
     ```
 


### PR DESCRIPTION
as for 
- [8.2](#arrows--implicit-return) If the function body consists of a single statement returning an [expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Expressions) without side effects, omit the braces and use the implicit return. Otherwise, keep the braces and use a `return` statement. eslint: [`arrow-parens`](https://eslint.org/docs/rules/arrow-parens.html), [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style.html)

we have to use explicit return statement if an expression has side effects