### PR TITLE
[guide] Fix description of rule 23.8 to specify `export-default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3308,7 +3308,7 @@ Other Style Guides
     ```
 
   <a name="naming--PascalCase-singleton"></a><a name="22.8"></a>
-  - [23.8](#naming--PascalCase-singleton) Use PascalCase when you export a constructor / class / singleton / function library / bare object.
+  - [23.8](#naming--PascalCase-singleton) Use PascalCase when you export-default a constructor / class / singleton / function library / bare object.
 
     ```javascript
     const AirbnbStyleGuide = {


### PR DESCRIPTION
Fixes the description of rule 23.8 to specify naming files in "PascalCase when you export-**default** a constructor", not when you merely export a constructor (i.e., among multiple exports).