### PR TITLE
Restrict empty lines at beginning of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2874,21 +2874,30 @@ Other Style Guides
   - [19.19](#whitespace--no-trailing-spaces) Avoid trailing spaces at the end of lines. eslint: [`no-trailing-spaces`](https://eslint.org/docs/rules/no-trailing-spaces)
 
   <a name="whitespace--no-multiple-empty-lines"></a>
-  - [19.20](#whitespace--no-multiple-empty-lines) Avoid multiple empty lines and only allow one newline at the end of files. eslint: [`no-multiple-empty-lines`](https://eslint.org/docs/rules/no-multiple-empty-lines)
+  - [19.20](#whitespace--no-multiple-empty-lines) Avoid multiple empty lines, only allow one newline at the end of files, and avoid a newline at the beginning of files. eslint: [`no-multiple-empty-lines`](https://eslint.org/docs/rules/no-multiple-empty-lines)
 
     <!-- markdownlint-disable MD012 -->
     ```javascript
-    // bad
+    // bad - multiple empty lines
     var x = 1;
 
 
+    var y = 2;
 
+    // bad - 2+ newlines at end of file
+    var x = 1;
+    var y = 2;
+
+
+    // bad - 1+ newline(s) at beginning of file
+
+    var x = 1;
     var y = 2;
 
     // good
     var x = 1;
-
     var y = 2;
+
     ```
     <!-- markdownlint-enable MD012 -->
 

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -308,8 +308,9 @@ module.exports = {
     // https://eslint.org/docs/rules/no-multi-assign
     'no-multi-assign': ['error'],
 
-    // disallow multiple empty lines and only one newline at the end
-    'no-multiple-empty-lines': ['error', { max: 2, maxEOF: 0 }],
+    // disallow multiple empty lines, only one newline at the end, and no new lines at the beginning
+    // https://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 1, maxEOF: 0 }],
 
     // disallow negated conditions
     // https://eslint.org/docs/rules/no-negated-condition


### PR DESCRIPTION
Related: #1794 (only covered EOF).

[no-multiple-empty-lines](https://eslint.org/docs/rules/no-multiple-empty-lines):

```
- "max" (default: 2) enforces a maximum number of consecutive empty lines.
- "maxEOF" enforces a maximum number of consecutive empty lines at the end of files.
- "maxBOF" enforces a maximum number of consecutive empty lines at the beginning of files.
```