### PR TITLE
Change link to new version of Google Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3697,7 +3697,8 @@ Other Style Guides
 
 **Other Style Guides**
 
-  - [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml)
+  - [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)
+  - [Google JavaScript Style Guide (Old)](https://google.github.io/styleguide/javascriptguide.xml)
   - [jQuery Core Style Guidelines](https://contribute.jquery.org/style-guide/js/)
   - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)
   - [StandardJS](https://standardjs.com)


### PR DESCRIPTION
Change link to a newer version of this guide that includes ECMAScript 6th Edition features