### PR TITLE
Update ref section

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -540,7 +540,7 @@ We don’t recommend using indexes for keys if the order of items may change.
           {props.items.map((item, index) => (
             <Item
               key={item.key}
-              onClick={(event) => doSomethingWith(event, item.name, index)}
+              onClick={(event) => { doSomethingWith(event, item.name, index); }}
             />
           ))}
         </ul>


### PR DESCRIPTION
I think we don't need ```{ }``` because it's a single line 
Updated method name from ```onClick``` to ```handleClick```
Removed unnecessary ```(event) =>``` when we have one argument ```event =>```
Importing ```import React from 'react'``` to ```import React, { Component } from 'react'```