### PR TITLE
Update eslint-config docs to explain hooks better

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -58,7 +58,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
 
 ### eslint-config/airbnb/hooks
 
-This entry point enables the linting rules for React hooks (requires v16.8+). To use, add `"extends": "airbnb/hooks"` to your `.eslintrc`
+This entry point enables the linting rules for React hooks (requires v16.8+). To use, add `"extends": ["airbnb", "airbnb/hooks"]` to your `.eslintrc`
 
 ### eslint-config-airbnb/whitespace
 


### PR DESCRIPTION
It took me too long to realize that `"extends": "airbnb/hooks"` won't cut it, and that you need to include both `"extends": ["airbnb", "airbnb/hooks"]`. I think the docs should be explicit about this.