### PR TITLE
eslint-config-airbnb: allow eslint-plugin-react-hooks 2

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^1.7.0"
+    "eslint-plugin-react-hooks": "^1.7.0 || ^2.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
This allows to install eslint-plugin-react-hooks 2 by adding it in peerDependencies