### PR TITLE
Enforce rule 7.9 in eslint (default-param-last)

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Other Style Guides
     ```
 
   <a name="functions--defaults-last"></a><a name="7.9"></a>
-  - [7.9](#functions--defaults-last) Always put default parameters last.
+  - [7.9](#functions--defaults-last) Always put default parameters last. eslint: [`default-param-last`](https://eslint.org/docs/rules/default-param-last)
 
     ```javascript
     // bad

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -57,7 +57,7 @@
     "babel-preset-airbnb": "^4.0.1",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.4.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
     "in-publish": "^2.0.0",

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -65,7 +65,7 @@
     "tape": "^4.11.0"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.4.0",
     "eslint-plugin-import": "^2.18.2"
   },
   "engines": {

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -73,6 +73,9 @@ module.exports = {
     // enforces consistent naming when capturing the current execution context
     'consistent-this': 'off',
 
+    // enforce that default parameters should come last
+    'default-param-last': ['error'],
+
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': ['error', 'always'],
 


### PR DESCRIPTION
Enforces the existing [airbnb style guide rule about default parameters coming last](https://github.com/airbnb/javascript#functions--defaults-last) in eslint by using [default-param-last](https://eslint.org/docs/rules/default-param-last).

As this rule was introduced in ESLint 6.4.0, I bumped the eslint version in `package.json` but I am not sure if that is the right thing to do? This is my first PR in this repository. 😨 