### PR TITLE
Add static-variables to sort-comp rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -240,6 +240,7 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/sort-comp.md
     'react/sort-comp': ['error', {
       order: [
+        'static-variables',
         'static-methods',
         'instance-variables',
         'lifecycle',


### PR DESCRIPTION
As requested here: https://github.com/airbnb/javascript/issues/2107 , this adds the `static-variables` rule added in `eslint-plugin-react@7.15.0` to the top of the `sort-comp` `order` configuration.

Closes #2107.