### PR TITLE
re-enable eslint rule `prefer-destructuring` internally

### DIFF
--- a/packages/eslint-config-airbnb-base/.eslintrc
+++ b/packages/eslint-config-airbnb-base/.eslintrc
@@ -4,7 +4,5 @@
     // disable requiring trailing commas because it might be nice to revert to
     // being JSON at some point, and I don't want to make big changes now.
     "comma-dangle": 0,
-    // we support node 4
-    "prefer-destructuring": 0,
   },
 }

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -1,6 +1,6 @@
 const assign = require('object.assign');
 const entries = require('object.entries');
-const CLIEngine = require('eslint').CLIEngine;
+const { CLIEngine } = require('eslint');
 
 const baseConfig = require('.');
 

--- a/packages/eslint-config-airbnb/.eslintrc
+++ b/packages/eslint-config-airbnb/.eslintrc
@@ -4,7 +4,5 @@
     // disable requiring trailing commas because it might be nice to revert to
     // being JSON at some point, and I don't want to make big changes now.
     "comma-dangle": 0,
-    // we support node 4
-    "prefer-destructuring": 0,
   },
 }

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -1,6 +1,6 @@
 const assign = require('object.assign');
 const entries = require('object.entries');
-const CLIEngine = require('eslint').CLIEngine;
+const { CLIEngine } = require('eslint');
 
 const baseConfig = require('.');
 


### PR DESCRIPTION
Previously eslint config of this repo disable rule `prefer-destructuring` because packages supported nodejs version 4.

But nodejs version 4 got support dropped recently, so this disablement is no longer needed.