### PR TITLE
remove redundant dependencies `object.assign`

### DIFF
--- a/packages/eslint-config-airbnb-base/.eslintrc
+++ b/packages/eslint-config-airbnb-base/.eslintrc
@@ -6,5 +6,7 @@
     "comma-dangle": 0,
     // we support node 4
     "prefer-destructuring": 0,
+    // we support node 6
+    "prefer-object-spread": 0,
   },
 }

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -73,7 +73,6 @@
   },
   "dependencies": {
     "confusing-browser-globals": "^1.0.9",
-    "object.assign": "^4.1.0",
     "object.entries": "^1.1.0"
   }
 }

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -1,11 +1,10 @@
-const assign = require('object.assign');
 const entries = require('object.entries');
 const CLIEngine = require('eslint').CLIEngine;
 
 const baseConfig = require('.');
 
 function onlyErrorOnRules(rulesToError, config) {
-  const errorsOnly = assign({}, config);
+  const errorsOnly = Object.assign({}, config);
   const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
   const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 

--- a/packages/eslint-config-airbnb/.eslintrc
+++ b/packages/eslint-config-airbnb/.eslintrc
@@ -6,5 +6,7 @@
     "comma-dangle": 0,
     // we support node 4
     "prefer-destructuring": 0,
+    // we support node 6
+    "prefer-object-spread": 0,
   },
 }

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -55,7 +55,6 @@
   "homepage": "https://github.com/airbnb/javascript",
   "dependencies": {
     "eslint-config-airbnb-base": "^14.0.0",
-    "object.assign": "^4.1.0",
     "object.entries": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -1,4 +1,3 @@
-const assign = require('object.assign');
 const baseStyleRules = require('eslint-config-airbnb-base/rules/style').rules;
 
 const dangleRules = baseStyleRules['no-underscore-dangle'];
@@ -17,7 +16,7 @@ module.exports = {
   // View link below for react rules documentation
   // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
   rules: {
-    'no-underscore-dangle': [dangleRules[0], assign({}, dangleRules[1], {
+    'no-underscore-dangle': [dangleRules[0], Object.assign({}, dangleRules[1], {
       allow: dangleRules[1].allow.concat(['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__']),
     })],
 

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -1,11 +1,10 @@
-const assign = require('object.assign');
 const entries = require('object.entries');
 const CLIEngine = require('eslint').CLIEngine;
 
 const baseConfig = require('.');
 
 function onlyErrorOnRules(rulesToError, config) {
-  const errorsOnly = assign({}, config);
+  const errorsOnly = Object.assign({}, config);
   const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
   const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 


### PR DESCRIPTION
We are now not supporting nodejs v4.
So we can now use builtin `Object.assign` and module `object.assign` is no longer needed.

PS. I have to disable `prefer-object-spread` because object spreading is not supported in nodejs v6 which we have supported