### PR TITLE
[eslint config][base][minor] enable `import/no-useless-path-segments` for commonjs

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -236,7 +236,7 @@ module.exports = {
 
     // Ensures that there are no useless path segments
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/no-useless-path-segments.md
-    'import/no-useless-path-segments': 'error',
+    'import/no-useless-path-segments': ['error', { "commonjs": true }],
 
     // dynamic imports require a leading comment with a webpackChunkName
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/dynamic-import-chunkname.md


### PR DESCRIPTION
Currently config of rule `import/no-useless-path-segments` applies to only esmodule imports, this PR is to tighten it to apply to commonjs `require` as well to match the guide.

Resolves #2077