### PR TITLE
Support karma config files in import/no-extraneous-dependencies

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -90,6 +90,7 @@ module.exports = {
         '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
+        '**/karma.conf.js' // karma config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
[Karma](https://karma-runner.github.io/) is a widely used test runner. In its config file, one should be allowed to import dev dependencies. That's why I added it to the lists of dev dependencies.