### PR TITLE
Opt-in, non-breaking TypeScript support

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -58,6 +58,12 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
 
 2. Add `"extends": "airbnb-base"` to your .eslintrc.
 
+### eslint-config-airbnb-base/typescript
+
+This entry point enables the linting rules for TypeScript (requires v2.8+). To use, add `"extends": ["airbnb-base", "airbnb-base/typescript"]` to your `.eslintrc`
+
+Additional, slower linting rules which require type checking may be enabled through `"airbnb-base/typescript/requiring-type-checking"`
+
 ### eslint-config-airbnb-base/legacy
 
 Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.

--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -10,7 +10,7 @@ We export two ESLint configurations for your usage.
 
 ### eslint-config-airbnb-base
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import` and optionally, `@typescript-eslint/eslint-plugin` along with `@typescript-eslint/parser`.
 
 1. Install the correct versions of each package, which are listed by the command:
 

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -66,11 +66,15 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-plugin-import": "^2.18.2"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {
+      "optional": true
+    },
+    "@typescript-eslint/parser": {
       "optional": true
     }
   },

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -65,8 +65,14 @@
     "tape": "^4.11.0"
   },
   "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-plugin-import": "^2.18.2"
+  },
+  "peerDependenciesMeta": {
+    "@typescript-eslint/eslint-plugin": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -54,6 +54,8 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "@babel/runtime": "^7.6.2",
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
     "babel-preset-airbnb": "^4.1.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",

--- a/packages/eslint-config-airbnb-base/typescript/index.js
+++ b/packages/eslint-config-airbnb-base/typescript/index.js
@@ -1,0 +1,80 @@
+const { rules: baseBestPracticesRules } = require('../rules/best-practices');
+const { rules: baseErrorsRules } = require('../rules/errors');
+const { rules: baseES6Rules } = require('../rules/es6');
+const { rules: baseStyleRules } = require('../rules/style');
+const { rules: baseVariablesRules } = require('../rules/variables');
+
+module.exports = {
+  extends: [
+    // disable checks overlapping with the ones built into ts
+    'plugin:@typescript-eslint/eslint-recommended',
+
+    // follow basic ts guidelines
+    'plugin:@typescript-eslint/recommended',
+
+    // add support for resolving ts imports
+    'plugin:import/typescript'
+  ],
+
+  rules: {
+    // interfaces can be implemented, extended and augmented
+    // https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#types-or-interfaces
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+
+    '@typescript-eslint/array-type': 'error',
+    '@typescript-eslint/member-ordering': 'error',
+    '@typescript-eslint/no-extraneous-class': 'error',
+    '@typescript-eslint/prefer-function-type': 'error',
+
+    /* override base config, preferring rules relying on type info: */
+
+    'brace-style': 'off',
+    '@typescript-eslint/brace-style': baseStyleRules['brace-style'],
+
+    camelcase: 'off',
+    '@typescript-eslint/camelcase': baseStyleRules.camelcase,
+
+    'func-call-spacing': 'off',
+    '@typescript-eslint/func-call-spacing': baseStyleRules['func-call-spacing'],
+
+    indent: 'off',
+    '@typescript-eslint/indent': baseStyleRules.indent,
+
+    'no-array-constructor': 'off',
+    '@typescript-eslint/no-array-constructor':
+      baseStyleRules['no-array-constructor'],
+
+    'no-empty-function': 'off',
+    '@typescript-eslint/no-empty-function':
+      baseBestPracticesRules['no-empty-function'],
+
+    'no-extra-parens': 'off',
+    '@typescript-eslint/no-extra-parens': baseErrorsRules['no-extra-parens'],
+
+    'no-magic-numbers': 'off',
+    '@typescript-eslint/no-magic-numbers':
+      baseBestPracticesRules['no-magic-numbers'],
+
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': baseVariablesRules['no-unused-vars'],
+
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      {
+        ...baseVariablesRules['no-use-before-define'][1],
+        typedefs: true
+      }
+    ],
+
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor':
+      baseES6Rules['no-useless-constructor'],
+
+    quotes: 'off',
+    '@typescript-eslint/quotes': baseStyleRules.quotes,
+
+    semi: 'off',
+    '@typescript-eslint/semi': baseStyleRules.semi
+  }
+};

--- a/packages/eslint-config-airbnb-base/typescript/requiring-type-checking.js
+++ b/packages/eslint-config-airbnb-base/typescript/requiring-type-checking.js
@@ -1,0 +1,31 @@
+const { rules: baseBestPracticesRules } = require('../rules/best-practices');
+
+module.exports = {
+  extends: 'plugin:@typescript-eslint/recommended-requiring-type-checking',
+
+  rules: {
+    '@typescript-eslint/member-ordering': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/no-misused-promises': 'error',
+    '@typescript-eslint/no-unnecessary-condition': [
+      'error',
+      { ignoreRhs: true }
+    ],
+
+    // specifying a default type which is then given may be a code smell
+    '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
+
+    '@typescript-eslint/prefer-regexp-exec': 'error',
+    '@typescript-eslint/promise-function-async': 'error',
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      { allowNullable: true, ignoreRhs: true }
+    ],
+    '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
+
+    /* override base config, preferring rules relying on type info: */
+
+    'require-await': 'off',
+    '@typescript-eslint/require-await': baseBestPracticesRules['require-await']
+  }
+};

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -56,9 +56,15 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
 
 2. Add `"extends": "airbnb"` to your `.eslintrc`
 
-### eslint-config/airbnb/hooks
+### eslint-config-airbnb/hooks
 
 This entry point enables the linting rules for React hooks (requires v16.8+). To use, add `"extends": ["airbnb", "airbnb/hooks"]` to your `.eslintrc`
+
+### eslint-config-airbnb/typescript
+
+This entry point enables the linting rules for TypeScript (requires v2.8+). To use, add `"extends": ["airbnb", "airbnb/typescript"]` to your `.eslintrc`
+
+Additional, slower linting rules which require type checking may be enabled through `"airbnb/typescript/requiring-type-checking"`
 
 ### eslint-config-airbnb/whitespace
 

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -10,7 +10,7 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-airbnb
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y`, and optionally, `@typescript-eslint/eslint-plugin` along with `@typescript-eslint/parser`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
 1. Install the correct versions of each package, which are listed by the command:
 

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -75,11 +75,21 @@
     "tape": "^4.11.0"
   },
   "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-react-hooks": "^1.7.0"
+  },
+  "peerDependenciesMeta": {
+    "@typescript-eslint/eslint-plugin": {
+      "optional": true
+    },
+    "@typescript-eslint/parser": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -60,6 +60,8 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.6.2",
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
     "babel-preset-airbnb": "^4.1.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",

--- a/packages/eslint-config-airbnb/typescript/index.js
+++ b/packages/eslint-config-airbnb/typescript/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extends: require.resolve('eslint-config-airbnb-base/typescript'),
+
+  rules: {
+    // allow .tsx files to have JSX
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
+    'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
+  },
+
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // using a type system makes it safe enough to spread props
+        'react/jsx-props-no-spreading': 'off',
+      },
+    },
+  ]
+};

--- a/packages/eslint-config-airbnb/typescript/requiring-type-checking.js
+++ b/packages/eslint-config-airbnb/typescript/requiring-type-checking.js
@@ -1,0 +1,31 @@
+const { rules: baseBestPracticesRules } = require('../rules/best-practices');
+
+module.exports = {
+  extends: 'plugin:@typescript-eslint/recommended-requiring-type-checking',
+
+  rules: {
+    '@typescript-eslint/member-ordering': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/no-misused-promises': 'error',
+    '@typescript-eslint/no-unnecessary-condition': [
+      'error',
+      { ignoreRhs: true }
+    ],
+
+    // specifying a default type which is then given may be a code smell
+    '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
+
+    '@typescript-eslint/prefer-regexp-exec': 'error',
+    '@typescript-eslint/promise-function-async': 'error',
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      { allowNullable: true, ignoreRhs: true }
+    ],
+    '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
+
+    /* override base config, preferring rules relying on type info: */
+
+    'require-await': 'off',
+    '@typescript-eslint/require-await': baseBestPracticesRules['require-await']
+  }
+};

--- a/packages/eslint-config-airbnb/typescript/requiring-type-checking.js
+++ b/packages/eslint-config-airbnb/typescript/requiring-type-checking.js
@@ -1,31 +1,5 @@
-const { rules: baseBestPracticesRules } = require('../rules/best-practices');
-
 module.exports = {
-  extends: 'plugin:@typescript-eslint/recommended-requiring-type-checking',
-
-  rules: {
-    '@typescript-eslint/member-ordering': 'error',
-    '@typescript-eslint/no-floating-promises': 'error',
-    '@typescript-eslint/no-misused-promises': 'error',
-    '@typescript-eslint/no-unnecessary-condition': [
-      'error',
-      { ignoreRhs: true }
-    ],
-
-    // specifying a default type which is then given may be a code smell
-    '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
-
-    '@typescript-eslint/prefer-regexp-exec': 'error',
-    '@typescript-eslint/promise-function-async': 'error',
-    '@typescript-eslint/strict-boolean-expressions': [
-      'error',
-      { allowNullable: true, ignoreRhs: true }
-    ],
-    '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
-
-    /* override base config, preferring rules relying on type info: */
-
-    'require-await': 'off',
-    '@typescript-eslint/require-await': baseBestPracticesRules['require-await']
-  }
+  extends: require.resolve(
+    'eslint-config-airbnb-base/typescript/requiring-type-checking'
+  )
 };


### PR DESCRIPTION
Inspired [by eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import#typescript), I decided to create sets of rules which add TypeScript support without modifying anything in the current configs. As Airbnb [has been adopting the language](https://www.youtube.com/watch?v=P-J9Eg7hJwE) lately, I felt it would be gentle to introduce official linting support for it.

The rules may be enabled through:

- airbnb/typescript
- airbnb/typescript/requiring-type-checking