### PR TITLE
Enforce filename match with default export

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -10,7 +10,7 @@ We export two ESLint configurations for your usage.
 
 ### eslint-config-airbnb-base
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-filenames` and `eslint-plugin-import`.
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -40,7 +40,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   Which produces and runs a command like:
 
   ```sh
-    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-filenames^#.#.# eslint-plugin-import@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -53,7 +53,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-filenames^#.#.# eslint-plugin-import@^#.#.#
   ```
 
 2. Add `"extends": "airbnb-base"` to your .eslintrc.

--- a/packages/eslint-config-airbnb-base/index.js
+++ b/packages/eslint-config-airbnb-base/index.js
@@ -6,6 +6,7 @@ module.exports = {
     './rules/style',
     './rules/variables',
     './rules/es6',
+    './rules/filenames',
     './rules/imports',
     './rules/strict',
   ].map(require.resolve),

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -59,6 +59,7 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-find-rules": "^3.4.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.18.2",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.3",
@@ -66,6 +67,7 @@
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.18.2"
   },
   "engines": {

--- a/packages/eslint-config-airbnb-base/rules/filenames.js
+++ b/packages/eslint-config-airbnb-base/rules/filenames.js
@@ -1,0 +1,9 @@
+module.exports = {
+  plugins: ['filenames'],
+
+  rules: {
+    // match filename against the default export, accepting kebab-cased names
+    // https://github.com/selaux/eslint-plugin-filenames#matching-exported-values-match-exported
+    'filenames/match-exported': ['error', [null, 'kebab']],
+  },
+};

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -10,7 +10,7 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-airbnb
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-filenames`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -39,7 +39,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-filenames@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -51,7 +51,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-filenames^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
 2. Add `"extends": "airbnb"` to your `.eslintrc`

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -65,6 +65,7 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-find-rules": "^3.4.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",
@@ -76,6 +77,7 @@
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",


### PR DESCRIPTION
According [to the style guide](https://github.com/airbnb/javascript#naming--filename-matches-export):

> A base filename should exactly match the name of its default export.

This can be enforced with [eslint-plugin-filenames](https://github.com/selaux/eslint-plugin-filenames), allowing kebab-cased names e.g. [for `files-which-correspond-to-a-url.js`](https://www.gatsbyjs.org/tutorial/part-one/#-using-page-components).