### PR TITLE
Enforce stricter module import order with autofix

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -10,7 +10,7 @@ We export two ESLint configurations for your usage.
 
 ### eslint-config-airbnb-base
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import` and `eslint-plugin-simple-import-sort`.
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -40,7 +40,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   Which produces and runs a command like:
 
   ```sh
-    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-simple-import-sort@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -53,7 +53,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-simple-import-sort@^#.#.#
   ```
 
 2. Add `"extends": "airbnb-base"` to your .eslintrc.

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -60,13 +60,15 @@
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-simple-import-sort": "^4.0.0",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.3",
     "tape": "^4.11.0"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-simple-import-sort": "^4.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -145,6 +145,7 @@ module.exports = {
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
     // TODO: enforce a stricter convention in module import order?
+    'import/order': 'off',
     'simple-import-sort/sort': 'error',
 
     // Require a newline after the last import/require in a group

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -7,7 +7,8 @@ module.exports = {
     sourceType: 'module'
   },
   plugins: [
-    'import'
+    'import',
+    'simple-import-sort'
   ],
 
   settings: {
@@ -144,7 +145,7 @@ module.exports = {
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
     // TODO: enforce a stricter convention in module import order?
-    'import/order': ['error', { groups: [['builtin', 'external', 'internal']] }],
+    'simple-import-sort/sort': 'error',
 
     // Require a newline after the last import/require in a group
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -10,7 +10,7 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-airbnb
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-simple-import-sort`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -39,7 +39,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-simple-import-sort@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -51,7 +51,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-simple-import-sort@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
 2. Add `"extends": "airbnb"` to your `.eslintrc`

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-simple-import-sort": "^4.0.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^1.1.3",
@@ -79,7 +80,8 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",
-    "eslint-plugin-react-hooks": "^1.7.0"
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-simple-import-sort": "^4.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
Using [eslint-plugin-simple-import-order](https://github.com/lydell/eslint-plugin-simple-import-sort), it is possible to maintain consistency of import declarations' order without developer interaction.