### PR TITLE
Enforce modern usage of Promises

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -10,7 +10,7 @@ We export two ESLint configurations for your usage.
 
 ### eslint-config-airbnb-base
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import` and `eslint-plugin-promise`.
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -40,7 +40,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   Which produces and runs a command like:
 
   ```sh
-    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-promise@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -53,7 +53,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-promise@^#.#.#
   ```
 
 2. Add `"extends": "airbnb-base"` to your .eslintrc.

--- a/packages/eslint-config-airbnb-base/index.js
+++ b/packages/eslint-config-airbnb-base/index.js
@@ -7,6 +7,7 @@ module.exports = {
     './rules/variables',
     './rules/es6',
     './rules/imports',
+    './rules/promises',
     './rules/strict',
   ].map(require.resolve),
   parserOptions: {

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -60,13 +60,15 @@
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "^4.2.1",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.3",
     "tape": "^4.11.0"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "^4.2.1"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb-base/rules/promises.js
+++ b/packages/eslint-config-airbnb-base/rules/promises.js
@@ -1,0 +1,42 @@
+module.exports = {
+  plugins: ['promise'],
+
+  rules: {
+    // avoid calling `new` on static Promise methods
+    'promise/no-new-statics': 'error',
+
+    // avoid wrapping into `Promise.resolve` or `Promise.reject` unnecessarily
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/no-return-wrap.md
+    'promise/no-return-wrap': 'error',
+
+    // enforce consistent param names and ordering
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/param-names.md
+    'promise/param-names': 'error',
+
+    // prefer `await` to `then()`
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md
+    'promise/prefer-await-to-then': 'error',
+
+    // callbacks are still in wide use, so they should be allowed
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-callbacks.md
+    'promise/prefer-await-to-callbacks': 'off',
+
+    // prefer creating Promises through the usage of async functions
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/avoid-new.md
+    'promise/avoid-new': 'error',
+
+    // would ensure the proper number of arguments are passed to Promise methods
+    // can be enforced through static type checking
+    // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/valid-params.md
+    'promise/valid-params': 'off',
+
+    /* rules below are redundant when using async/await syntax: */
+    'promise/catch-or-return': 'off',
+    'promise/always-return': 'off',
+    'promise/no-native': 'off',
+    'promise/no-nesting': 'off',
+    'promise/no-promise-in-callback': 'off',
+    'promise/no-callback-in-promise': 'off',
+    'promise/no-return-in-finally': 'off'
+  },
+};

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -10,7 +10,7 @@ We export three ESLint configurations for your usage.
 
 ### eslint-config-airbnb
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-promise`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
 
 1. Install the correct versions of each package, which are listed by the command:
 
@@ -39,7 +39,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
   If using **npm < 5**, Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
@@ -51,7 +51,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+ and
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
+  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-react@^#.#.# eslint-plugin-react-hooks@^#.#.#
   ```
 
 2. Add `"extends": "airbnb"` to your `.eslintrc`

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -67,6 +67,7 @@
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-react-hooks": "^1.7.0",
     "in-publish": "^2.0.0",
@@ -78,6 +79,7 @@
     "eslint": "^5.16.0 || ^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-react-hooks": "^1.7.0"
   },


### PR DESCRIPTION
As `async`/`await` syntax is spreading across the ecosystem with native support from [Node.js](https://node.green/), [browsers](https://caniuse.com/#feat=async-functions) and transpilers, they may be preferred over Promises.