### PR TITLE
[eslint-config] add browser env for react

### DIFF
--- a/packages/eslint-config-airbnb/index.js
+++ b/packages/eslint-config-airbnb/index.js
@@ -4,5 +4,8 @@ module.exports = {
     './rules/react',
     './rules/react-a11y',
   ].map(require.resolve),
+  env: {
+    browser: true
+  },
   rules: {}
 };


### PR DESCRIPTION
Similar to how

```js
env: {
  node: true
}
```

is [specified](https://github.com/airbnb/javascript/blob/64b965efe0355c8290996ff5a675cd8fb30bf843/packages/eslint-config-airbnb-base/rules/node.js#L2-L4) in the base ruleset, the `browser` environment should be enabled in the frontend-optimized React configuration.