### PR TITLE
Change jsx-a11y/label-has-associated-control from both to either

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -58,12 +58,11 @@ module.exports = {
     }],
 
     // Enforce that a label tag has a text label and an associated control.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/b800f40a2a69ad48015ae9226fbe879f946757ed/docs/rules/label-has-associated-control.md
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md
     'jsx-a11y/label-has-associated-control': ['error', {
       labelComponents: [],
       labelAttributes: [],
       controlComponents: [],
-      assert: 'both',
       depth: 25
     }],
 


### PR DESCRIPTION
According to the [documentation](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md), **either** `htmlFor` or `nesting` should work. Enforcing `both` will make developers' life much harder. In many designs, you need detached label and input elements.