### PR TITLE
normalize multiline word according to merriam-webster

### DIFF
--- a/README.md
+++ b/README.md
@@ -2120,7 +2120,7 @@ Other Style Guides
 ## Blocks
 
   <a name="blocks--braces"></a><a name="16.1"></a>
-  - [16.1](#blocks--braces) Use braces with all multi-line blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
+  - [16.1](#blocks--braces) Use braces with all multiline blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
 
     ```javascript
     // bad
@@ -2145,7 +2145,7 @@ Other Style Guides
     ```
 
   <a name="blocks--cuddled-elses"></a><a name="16.2"></a>
-  - [16.2](#blocks--cuddled-elses) If you’re using multi-line blocks with `if` and `else`, put `else` on the same line as your `if` block’s closing brace. eslint: [`brace-style`](https://eslint.org/docs/rules/brace-style.html)
+  - [16.2](#blocks--cuddled-elses) If you’re using multiline blocks with `if` and `else`, put `else` on the same line as your `if` block’s closing brace. eslint: [`brace-style`](https://eslint.org/docs/rules/brace-style.html)
 
     ```javascript
     // bad
@@ -2307,7 +2307,7 @@ Other Style Guides
 ## Comments
 
   <a name="comments--multiline"></a><a name="17.1"></a>
-  - [18.1](#comments--multiline) Use `/** ... */` for multi-line comments.
+  - [18.1](#comments--multiline) Use `/** ... */` for multiline comments.
 
     ```javascript
     // bad

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -57,7 +57,7 @@
     "babel-preset-airbnb": "^4.1.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.7.2",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
     "in-publish": "^2.0.0",
@@ -65,7 +65,7 @@
     "tape": "^4.11.0"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.7.2",
     "eslint-plugin-import": "^2.18.2"
   },
   "engines": {

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -43,6 +43,11 @@ module.exports = {
     // https://eslint.org/docs/rules/eqeqeq
     eqeqeq: ['error', 'always', { null: 'ignore' }],
 
+    // Require grouped accessor pairs in object literals and classes
+    // https://eslint.org/docs/rules/grouped-accessor-pairs
+    // TODO: enable in next major, altho the guide forbids getters/setters anyways
+    'grouped-accessor-pairs': 'off',
+
     // make sure for-in loops have an if statement
     'guard-for-in': 'error',
 
@@ -59,6 +64,11 @@ module.exports = {
     // disallow lexical declarations in case/default clauses
     // https://eslint.org/docs/rules/no-case-declarations.html
     'no-case-declarations': 'error',
+
+    // Disallow returning value in constructor
+    // https://eslint.org/docs/rules/no-constructor-return
+    // TODO: enable, semver-major
+    'no-constructor-return': 'off',
 
     // disallow division operators explicitly at beginning of regular expression
     // https://eslint.org/docs/rules/no-div-regex

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -23,7 +23,7 @@ module.exports = {
     'consistent-return': 'error',
 
     // specify curly brace conventions for all control statements
-    curly: ['error', 'multi-line'],
+    curly: ['error', 'multi-line'], // multiline
 
     // require default case in switch statements
     'default-case': ['error', { commentPattern: '^no default$' }],

--- a/packages/eslint-config-airbnb-base/rules/errors.js
+++ b/packages/eslint-config-airbnb-base/rules/errors.js
@@ -38,6 +38,11 @@ module.exports = {
     // disallow duplicate arguments in functions
     'no-dupe-args': 'error',
 
+    // Disallow duplicate conditions in if-else-if chains
+    // https://eslint.org/docs/rules/no-dupe-else-if
+    // TODO: enable, semver-major
+    'no-dupe-else-if': 'off',
+
     // disallow duplicate keys when creating object literals
     'no-dupe-keys': 'error',
 
@@ -99,6 +104,11 @@ module.exports = {
 
     // disallow multiple spaces in a regular expression literal
     'no-regex-spaces': 'error',
+
+    // Disallow returning values from setters
+    // https://eslint.org/docs/rules/no-setter-return
+    // TODO: enable, semver-major (altho the guide forbids getters/setters already)
+    'no-setter-return': 'off',
 
     // disallow sparse arrays
     'no-sparse-arrays': 'error',

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -237,7 +237,7 @@ module.exports = {
 
     // Ensures that there are no useless path segments
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/no-useless-path-segments.md
-    'import/no-useless-path-segments': ['error', { "commonjs": true }],
+    'import/no-useless-path-segments': ['error', { commonjs: true }],
 
     // dynamic imports require a leading comment with a webpackChunkName
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/dynamic-import-chunkname.md

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -434,6 +434,11 @@ module.exports = {
     // https://eslint.org/docs/rules/padding-line-between-statements
     'padding-line-between-statements': 'off',
 
+    // Disallow the use of Math.pow in favor of the ** operator
+    // https://eslint.org/docs/rules/prefer-exponentiation-operator
+    // TODO: enable, semver-major when eslint 5 is dropped
+    'prefer-exponentiation-operator': 'off',
+
     // Prefer use of an object spread over Object.assign
     // https://eslint.org/docs/rules/prefer-object-spread
     'prefer-object-spread': 'error',

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -4,6 +4,18 @@ const { CLIEngine } = require('eslint');
 
 const baseConfig = require('.');
 
+const severities = ['off', 'warn', 'error'];
+
+function getSeverity(ruleConfig) {
+  if (Array.isArray(ruleConfig)) {
+    return getSeverity(ruleConfig[0]);
+  }
+  if (typeof ruleConfig === 'number') {
+    return severities[ruleConfig];
+  }
+  return ruleConfig;
+}
+
 function onlyErrorOnRules(rulesToError, config) {
   const errorsOnly = assign({}, config);
   const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
@@ -12,8 +24,9 @@ function onlyErrorOnRules(rulesToError, config) {
   entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
+    const severity = getSeverity(ruleConfig);
 
-    if (rulesToError.indexOf(ruleName) === -1) {
+    if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
       if (Array.isArray(ruleConfig)) {
         errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
       } else if (typeof ruleConfig === 'number') {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -63,7 +63,7 @@
     "babel-preset-airbnb": "^4.1.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.7.2",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
@@ -75,7 +75,7 @@
     "tape": "^4.11.0"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.1.0",
+    "eslint": "^5.16.0 || ^6.7.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.15.1",

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -4,6 +4,18 @@ const { CLIEngine } = require('eslint');
 
 const baseConfig = require('.');
 
+const severities = ['off', 'warn', 'error'];
+
+function getSeverity(ruleConfig) {
+  if (Array.isArray(ruleConfig)) {
+    return getSeverity(ruleConfig[0]);
+  }
+  if (typeof ruleConfig === 'number') {
+    return severities[ruleConfig];
+  }
+  return ruleConfig;
+}
+
 function onlyErrorOnRules(rulesToError, config) {
   const errorsOnly = assign({}, config);
   const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
@@ -12,8 +24,9 @@ function onlyErrorOnRules(rulesToError, config) {
   entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
+    const severity = getSeverity(ruleConfig);
 
-    if (rulesToError.indexOf(ruleName) === -1) {
+    if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
       if (Array.isArray(ruleConfig)) {
         errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
       } else if (typeof ruleConfig === 'number') {

--- a/react/README.md
+++ b/react/README.md
@@ -514,7 +514,7 @@ We don’t recommend using indexes for keys if the order of items may change.
     <Foo variant="stuff" />
     ```
 
-  - If your component has multi-line properties, close its tag on a new line. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
+  - If your component has multiline properties, close its tag on a new line. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
 
     ```jsx
     // bad


### PR DESCRIPTION
"multiline" = 44 matches in 9 files
"multi-line" = 5 matches in 3 files

It seems that the former is preferred.

Also merriam-webster confirms it:
```
$ curl -I https://www.merriam-webster.com/dictionary/multi-line
HTTP/2 301
location: /dictionary/multiline
```
