### PR TITLE
[guide]Fix Type Error issue occur because of default value of function…

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,8 +757,16 @@ Other Style Guides
       // ...
     }
 
-    // good
+    // bad
+    // Invoke 'handleThings' function by passing null as an argument it will give you an error if you access property of opts object by using dot(.) notation in the body of 'handleThings' function. 
     function handleThings(opts = {}) {
+      // ...
+    }
+
+    //good
+    //It is good because it won't give you TypeError if you access any property of 'newOpts' by using dot(.) notation.
+    function handleThings(opts) {
+      const newOpts = opts || {}
       // ...
     }
     ```


### PR DESCRIPTION
In javascript style guide, According to rule 7.7, if i trying to access property key of opts by using dot notation(.) or square bracket([]) there is chances of  type error.
Why?
Because, if opts receive null value when 'handleThings' function invoked then default value empty object({}) not assign to the opts argument. So, this is happen then user will get uncaught type error.
Example:
```
function handleThings(opts = {}) {
console.log(opts.notificationEnabled)
 }
handleThings(null)
```
When you run this code you will get an error called "Uncaught TypeError: Cannot read property 'notificationEnabled' of null".