### PR TITLE
Fix indentation with JSX Fragments

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -74,6 +74,6 @@
   "dependencies": {
     "confusing-browser-globals": "^1.0.9",
     "object.assign": "^4.1.0",
-    "object.entries": "^1.1.0"
+    "object.entries": "^1.1.1"
   }
 }

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -53,16 +53,16 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "@babel/runtime": "^7.6.2",
-    "babel-preset-airbnb": "^4.1.0",
+    "@babel/runtime": "^7.8.4",
+    "babel-preset-airbnb": "^4.4.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.7.2",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.18.2",
     "in-publish": "^2.0.0",
-    "safe-publish-latest": "^1.1.3",
-    "tape": "^4.11.0"
+    "safe-publish-latest": "^1.1.4",
+    "tape": "^5.0.0-next.4"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.7.2",

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -59,14 +59,14 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.7.2",
     "eslint-find-rules": "^3.4.0",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.20.1",
     "in-publish": "^2.0.0",
     "safe-publish-latest": "^1.1.4",
     "tape": "^5.0.0-next.4"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.7.2",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.20.1"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -143,7 +143,7 @@ module.exports = {
       ImportDeclaration: 1,
       flatTernaryExpressions: false,
       // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
-      ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
+      ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXFragment', 'JSXOpeningFragment', 'JSXClosingFragment', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
       ignoreComments: false
     }],
 

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^14.0.0",
     "object.assign": "^4.1.0",
-    "object.entries": "^1.1.0"
+    "object.entries": "^1.1.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.6.2",

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -65,9 +65,9 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.7.2",
     "eslint-find-rules": "^3.4.0",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.15.1",
+    "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
@@ -76,9 +76,9 @@
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.7.2",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.15.1",
+    "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^1.7.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -59,8 +59,8 @@
     "object.entries": "^1.1.1"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.6.2",
-    "babel-preset-airbnb": "^4.1.0",
+    "@babel/runtime": "^7.8.4",
+    "babel-preset-airbnb": "^4.4.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.7.2",
@@ -71,8 +71,8 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
-    "safe-publish-latest": "^1.1.3",
-    "tape": "^4.11.0"
+    "safe-publish-latest": "^1.1.4",
+    "tape": "^5.0.0-next.4"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.7.2",


### PR DESCRIPTION
This PR fix an indentation issue with Fragment:

Before:
```js
// in render method

{process.env.NODE_ENV === 'development'
&& typeof retry === 'function' ? (
  <>
      {' '}
      <button onClick={retry} type="button" className="btn btn-default">
      <FormattedMessage id="retry" defaultMessage="Retry" />
    </button>
    </>
  ) : null}
```

After:
```js
{process.env.NODE_ENV === 'development'
&& typeof retry === 'function' ? (
  <>
    {' '}
    <button onClick={retry} type="button" className="btn btn-default">
      <FormattedMessage id="retry" defaultMessage="Retry" />
    </button>
  </>
  ) : null}
```