### PR TITLE
Fix typo in no-multiple-empty-lines rule

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -313,7 +313,7 @@ module.exports = {
 
     // disallow multiple empty lines, only one newline at the end, and no new lines at the beginning
     // https://eslint.org/docs/rules/no-multiple-empty-lines
-    'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 1, maxEOF: 0 }],
+    'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 0, maxEOF: 0 }],
 
     // disallow negated conditions
     // https://eslint.org/docs/rules/no-negated-condition

--- a/packages/eslint-config-airbnb/test/test-react-order.js
+++ b/packages/eslint-config-airbnb/test/test-react-order.js
@@ -24,7 +24,7 @@ function lint(text) {
 }
 
 function wrapComponent(body) {
-  return `
+  return `\
 import React from 'react';
 
 export default class MyComponent extends React.Component {


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because the Airbnb documentation states to "avoid a
newline at the beginning of files", yet the code does not follow this.

 ## What has changed to address the problem?

This change fixes the `no-multiple-empty-lines` rule by setting max
beginning of file (`maxBOF`) to from 1 to 0.

 ## How was this change tested?

This change was tested with `npm test`.

 ## Related docs

https://github.com/airbnb/javascript#whitespace--no-multiple-empty-lines

Fixes #2140 