### PR TITLE
update: primitives type(add "bigint")

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Other Style Guides
     - `null`
     - `undefined`
     - `symbol`
+    - `bigint`
 
     ```javascript
     const foo = 1;
@@ -81,7 +82,7 @@ Other Style Guides
     console.log(foo, bar); // => 1, 9
     ```
 
-    - Symbols cannot be faithfully polyfilled, so they should not be used when targeting browsers/environments that don’t support them natively.
+    - Symbols and BigInts cannot be faithfully polyfilled, so they should not be used when targeting browsers/environments that don’t support them natively.
 
   <a name="types--complex"></a><a name="1.2"></a>
   - [1.2](#types--complex)  **Complex**: When you access a complex type you work on a reference to its value.


### PR DESCRIPTION
add "bigint" type to the primitives type section.

I believe there is another primitives type in JS(may like symbol is new?).

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures

# use example:

```js
var bn = 123n
```
(with "n" as suffix)