### PR TITLE
update: import/extensions rule documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1441,6 +1441,23 @@ Other Style Guides
     import barCss from 'bar.css';
     ```
 
+  <a name="modules--import-extensions"></a>
+  - [10.10](#modules--import-extensions) Do not include JavaScript filename extensions
+ eslint: [`import/extensions`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md)
+    > Why? Including extensions inhibits refactoring, and inappropriately hardcodes implementation details of the module you're importing in every consumer.
+
+    ```javascript
+    // bad
+    import foo from './foo.js';
+    import bar from './bar.jsx';
+    import baz from './baz/index.jsx';
+
+    // good
+    import foo from './foo';
+    import bar from './bar';
+    import baz from './baz';
+    ```
+
 **[⬆ back to top](#table-of-contents)**
 
 ## Iterators and Generators


### PR DESCRIPTION
Add documentation for import extension rules https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js#L138

Let me know if example needs changing or added anywhere else :) 
```
    // bad
    import foo from './foo.js';
    import bar from './bar.jsx';

    // good
    import foo from './foo';
    import bar from './bar';
```

Fixes #2134