### PR TITLE
Include 'context' exception for no-param-reassign

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -194,6 +194,7 @@ module.exports = {
         'accumulator', // for reduce accumulators
         'e', // for e.returnvalue
         'ctx', // for Koa routing
+        'context', // for Koa routing
         'req', // for Express requests
         'request', // for Express requests
         'res', // for Express responses


### PR DESCRIPTION
Similar to [accumulator](https://github.com/airbnb/javascript/issues/1767), the full word carries more meaning and is more accessible for developers less familiar with JS idioms. Same goes for existing `req` -> `request`, etc.

Would be nice to have `ctx` full word version too.