### PR TITLE
set explicitSpread to ignore for `react/jsx-props-no-spreading`

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -494,6 +494,7 @@ module.exports = {
     'react/jsx-props-no-spreading': ['error', {
       html: 'enforce',
       custom: 'enforce',
+      explicitSpread: 'ignore',
       exceptions: [],
     }],
 


### PR DESCRIPTION
This PR adds an `ignore` setting for the `explicitSpread` attribute on the react/jsx-props-no-spreading rule (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md). 

This will set the rules to match the exception stated in the README

---
Closes #2236