### PR TITLE
remove import/no-cycle maxDepth

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -233,7 +233,7 @@ module.exports = {
 
     // Forbid cyclical dependencies between modules
     // https://github.com/benmosher/eslint-plugin-import/blob/d81f48a2506182738409805f5272eff4d77c9348/docs/rules/no-cycle.md
-    'import/no-cycle': ['error', { maxDepth: Infinity }],
+    'import/no-cycle': ['error'],
 
     // Ensures that there are no useless path segments
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/no-useless-path-segments.md


### PR DESCRIPTION
removes import/no-cycle maxDepth since from [its description](https://github.com/benmosher/eslint-plugin-import/blob/v2.21.2/docs/rules/no-cycle.md) it seems to be Infinity by default.

Also fixes https://github.com/airbnb/javascript/issues/2245