### PR TITLE
bug: import/no-cycle specifies Infinity

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -59,14 +59,14 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-find-rules": "^3.5.0",
-    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-import": "^2.22.0",
     "in-publish": "^2.0.1",
     "safe-publish-latest": "^1.1.4",
     "tape": "^5.0.1"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-    "eslint-plugin-import": "^2.21.2"
+    "eslint-plugin-import": "^2.22.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -233,7 +233,7 @@ module.exports = {
 
     // Forbid cyclical dependencies between modules
     // https://github.com/benmosher/eslint-plugin-import/blob/d81f48a2506182738409805f5272eff4d77c9348/docs/rules/no-cycle.md
-    'import/no-cycle': ['error', { maxDepth: Infinity }],
+    'import/no-cycle': ['error', { maxDepth: '∞' }],
 
     // Ensures that there are no useless path segments
     // https://github.com/benmosher/eslint-plugin-import/blob/ebafcbf59ec9f653b2ac2a0156ca3bcba0a7cf57/docs/rules/no-useless-path-segments.md

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -65,7 +65,7 @@
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-find-rules": "^3.5.0",
-    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.0",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0",
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.0",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0"


### PR DESCRIPTION
The configuration of the rule `import/no-cycle` specifies a maxDepth of `infinity`, which while reasonable, causes an error. This can be replicated by checking out the repo, and running `npm run lint`

```bash
/packages/eslint-config-airbnb-base ❯ npm run lint
...
...
...
> eslint-config-airbnb-base@14.2.0 lint /Users/philihp/work/javascript/packages/eslint-config-airbnb-base
> eslint --report-unused-disable-directives .

Oops! Something went wrong! :(

ESLint: 7.3.0

Error: .eslintrc » ./index.js » /Users/philihp/work/javascript/packages/eslint-config-airbnb-base/rules/imports.js:
	Configuration for rule "import/no-cycle" is invalid:
	Value null should be integer.

/packages/eslint-config-airbnb-base ❯ node -v && npm -v
v14.4.0
6.14.5
```

Since `Infinity` [is the default](https://github.com/benmosher/eslint-plugin-import/blob/master/src/rules/no-cycle.js#L35) for the rule, removing this would resolve the error.