### PR TITLE
Update the rule about Avoid duplicate class members in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1253,6 +1253,13 @@ Other Style Guides
     class Foo {
       bar() { return 2; }
     }
+    
+    // good
+    class Foo {
+      increase(x) { return x+1; }
+      // overloading is allowed
+      increase(x, y) { retun x+y; }
+    }
     ```
 
   <a name="classes--methods-use-this"></a>

--- a/README.md
+++ b/README.md
@@ -1253,7 +1253,7 @@ Other Style Guides
     class Foo {
       bar() { return 2; }
     }
-    
+
     // good
     class Foo {
       increase(x) { return x+1; }

--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,7 @@ Other Style Guides
     class Foo {
       increase(x) { return x+1; }
       // overloading is allowed
-      increase(x, y) { retun x+y; }
+      increase(x, y) { return x+y; }
     }
     ```
 


### PR DESCRIPTION
It is unclear from rule [`9.7`](https://github.com/airbnb/javascript#classes--methods-use-this) if overloading is allowed.

Beginners might get the assumption that even overloading isn't allowed since it has the same method name.
Hence, an example showing *overloading* under the `good` comment will solve that possible wrong assumption.