### PR TITLE
Better link reference to Drupal's linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3860,7 +3860,7 @@ Other Style Guides
   - **DailyMotion**: [dailymotion/javascript](https://github.com/dailymotion/javascript)
   - **DoSomething**: [DoSomething/eslint-config](https://github.com/DoSomething/eslint-config)
   - **Digitpaint** [digitpaint/javascript](https://github.com/digitpaint/javascript)
-  - **Drupal**: [www.drupal.org](https://www.drupal.org/project/drupal)
+  - **Drupal**: [www.drupal.org](https://git.drupalcode.org/project/drupal/blob/8.6.x/core/.eslintrc.json)
   - **Ecosia**: [ecosia/javascript](https://github.com/ecosia/javascript)
   - **Evernote**: [evernote/javascript-style-guide](https://github.com/evernote/javascript-style-guide)
   - **Evolution Gaming**: [evolution-gaming/javascript](https://github.com/evolution-gaming/javascript)


### PR DESCRIPTION
This link was taken from their Code standard page: https://www.drupal.org/docs/develop/standards/javascript/eslint-settings

The previous link wasn't very informative and required a download process in order to check their standards.