### PR TITLE
README: Fix section 3.2 "good" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Other Style Guides
     const obj = {
       id: 5,
       name: 'San Francisco',
-      [getKey('enabled')]: true,
+      getKey('enabled'): true,
     };
     ```
 


### PR DESCRIPTION
In the 3.2 section of the **Airbnb JavaScript Style Guide**, the "good" and "bad" example don't appear to be equivalent.