### PR TITLE
Fix ignoreNonDOM typo in jsx-a11y/aria-role rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -17,7 +17,7 @@ module.exports = {
 
     // Require ARIA roles to be valid and non-abstract
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
-    'jsx-a11y/aria-role': ['error', { ignoreNonDom: false }],
+    'jsx-a11y/aria-role': ['error', { ignoreNonDOM: false }],
 
     // Enforce all aria-* props are valid.
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md


### PR DESCRIPTION
This should be `ignoreNonDOM` not `ignoreNonDom` according to [documentation](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md).