### PR TITLE
Allow missing React when using JSX (React 17)

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -224,10 +224,6 @@ module.exports = {
       skipUndeclared: false
     }],
 
-    // Prevent missing React when using JSX
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
-    'react/react-in-jsx-scope': 'error',
-
     // Require render() methods to return something
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
     'react/require-render-return': 'error',


### PR DESCRIPTION
Since React 17, `import React` is [no longer required](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) for JSX files to correctly transform. 

This is possible through an [update available since `@babel/plugin-transform-react-jsx` 7.9.0](https://github.com/babel/babel/pull/11154). `babel-preset-airbnb` is [already using this version](https://github.com/airbnb/babel-preset-airbnb/blob/master/package.json#L33).