### PR TITLE
remove deprecated accessible-emoji rule

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -178,10 +178,6 @@ module.exports = {
       ]
     }],
 
-    // ensure emoji are accessible
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
-    'jsx-a11y/accessible-emoji': 'error',
-
     // elements with aria-activedescendant must be tabbable
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md
     'jsx-a11y/aria-activedescendant-has-tabindex': 'error',


### PR DESCRIPTION
`jsx-a11y/accessible-emoji` is deprecated and will be removed in a future version, see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/713 and https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627

This PR is a proposal to remove the `jsx-a11y/accessible-emoji` rule