### PR TITLE
Add `.eslintrc.js` to `import/no-extraneous-dependencies` devDeps

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -90,7 +90,8 @@ module.exports = {
         '**/Gruntfile{,.js}', // grunt config
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
-        '**/karma.conf.js' // karma config
+        '**/karma.conf.js', // karma config
+        '**/.eslintrc.js' // eslint config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
Similar to #1168 and #1522

Since you can import dev dependencies in a `.eslintrc.js` file, I may be interesting to disable devDeps check in this file. 

WDYT? Thanks!