### PR TITLE
Alphabetize the rules for react-a11y.js

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-import": "^2.22.1",
     "in-publish": "^2.0.1",
     "safe-publish-latest": "^1.1.4",
-    "tape": "^5.1.0"
+    "tape": "^5.2.2"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -59,7 +59,7 @@
     "object.entries": "^1.1.3"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.12.5",
+    "@babel/runtime": "^7.13.10",
     "babel-preset-airbnb": "^4.5.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
@@ -67,7 +67,7 @@
     "eslint-find-rules": "^3.6.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0",
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
@@ -78,7 +78,7 @@
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -72,7 +72,7 @@
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^1.1.4",
-    "tape": "^5.1.0"
+    "tape": "^5.2.2"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",

--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -11,26 +11,10 @@ module.exports = {
   },
 
   rules: {
-    // Enforce that anchors have content
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
-    'jsx-a11y/anchor-has-content': ['error', { components: [] }],
-
-    // Require ARIA roles to be valid and non-abstract
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
-    'jsx-a11y/aria-role': ['error', { ignoreNonDOM: false }],
-
-    // Enforce all aria-* props are valid.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
-    'jsx-a11y/aria-props': 'error',
-
-    // Enforce ARIA state and property values are valid.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
-    'jsx-a11y/aria-proptypes': 'error',
-
-    // Enforce that elements that do not support ARIA roles, states, and
-    // properties do not have those attributes.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
-    'jsx-a11y/aria-unsupported-elements': 'error',
+    // ensure emoji are accessible
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
+    // disabled; rule is deprecated
+    'jsx-a11y/accessible-emoji': 'off',
 
     // Enforce that all elements that require alternative text have meaningful information
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
@@ -42,30 +26,48 @@ module.exports = {
       'input[type="image"]': [],
     }],
 
-    // Prevent img alt text from containing redundant words like "image", "picture", or "photo"
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
-    'jsx-a11y/img-redundant-alt': 'error',
+    // Enforce that anchors have content
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
+    'jsx-a11y/anchor-has-content': ['error', { components: [] }],
 
-    // require that JSX labels use "htmlFor"
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-    // deprecated: replaced by `label-has-associated-control` rule
-    'jsx-a11y/label-has-for': ['off', {
-      components: [],
-      required: {
-        every: ['nesting', 'id'],
-      },
-      allowChildren: false,
+    // ensure <a> tags are valid
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/0745af376cdc8686d85a361ce36952b1fb1ccf6e/docs/rules/anchor-is-valid.md
+    'jsx-a11y/anchor-is-valid': ['error', {
+      components: ['Link'],
+      specialLink: ['to'],
+      aspects: ['noHref', 'invalidHref', 'preferButton'],
     }],
 
-    // Enforce that a label tag has a text label and an associated control.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/b800f40a2a69ad48015ae9226fbe879f946757ed/docs/rules/label-has-associated-control.md
-    'jsx-a11y/label-has-associated-control': ['error', {
-      labelComponents: [],
-      labelAttributes: [],
-      controlComponents: [],
-      assert: 'both',
-      depth: 25
+    // elements with aria-activedescendant must be tabbable
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
+
+    // Enforce all aria-* props are valid.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
+    'jsx-a11y/aria-props': 'error',
+
+    // Enforce ARIA state and property values are valid.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
+    'jsx-a11y/aria-proptypes': 'error',
+
+    // Require ARIA roles to be valid and non-abstract
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
+    'jsx-a11y/aria-role': ['error', { ignoreNonDOM: false }],
+
+    // Enforce that elements that do not support ARIA roles, states, and
+    // properties do not have those attributes.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
+    'jsx-a11y/aria-unsupported-elements': 'error',
+
+    // Ensure the autocomplete attribute is correct and suitable for the form field it is used with
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/29c68596b15c4ff0a40daae6d4a2670e36e37d35/docs/rules/autocomplete-valid.md
+    'jsx-a11y/autocomplete-valid': ['off', {
+      inputComponents: [],
     }],
+
+    // require onClick be accompanied by onKeyUp/onKeyDown/onKeyPress
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
+    'jsx-a11y/click-events-have-key-events': 'error',
 
     // Enforce that a control (an interactive element) has a text label.
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/control-has-associated-label.md
@@ -96,36 +98,6 @@ module.exports = {
       depth: 5,
     }],
 
-    // require that mouseover/out come with focus/blur, for keyboard-only users
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
-    'jsx-a11y/mouse-events-have-key-events': 'error',
-
-    // Prevent use of `accessKey`
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
-    'jsx-a11y/no-access-key': 'error',
-
-    // require onBlur instead of onChange
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
-    'jsx-a11y/no-onchange': 'off',
-
-    // Elements with an interactive role and interaction handlers must be focusable
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
-    'jsx-a11y/interactive-supports-focus': 'error',
-
-    // Enforce that elements with ARIA roles must have all required attributes
-    // for that role.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
-    'jsx-a11y/role-has-required-aria-props': 'error',
-
-    // Enforce that elements with explicit or implicit roles defined contain
-    // only aria-* properties supported by that role.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
-    'jsx-a11y/role-supports-aria-props': 'error',
-
-    // Enforce tabIndex value is not greater than zero.
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
-    'jsx-a11y/tabindex-no-positive': 'error',
-
     // ensure <hX> tags have content and are not aria-hidden
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
     'jsx-a11y/heading-has-content': ['error', { components: [''] }],
@@ -134,9 +106,51 @@ module.exports = {
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/html-has-lang.md
     'jsx-a11y/html-has-lang': 'error',
 
+    // ensure iframe elements have a unique title
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md
+    'jsx-a11y/iframe-has-title': 'error',
+
+    // Prevent img alt text from containing redundant words like "image", "picture", or "photo"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
+    'jsx-a11y/img-redundant-alt': 'error',
+
+    // Elements with an interactive role and interaction handlers must be focusable
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
+    'jsx-a11y/interactive-supports-focus': 'error',
+
+    // Enforce that a label tag has a text label and an associated control.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/b800f40a2a69ad48015ae9226fbe879f946757ed/docs/rules/label-has-associated-control.md
+    'jsx-a11y/label-has-associated-control': ['error', {
+      labelComponents: [],
+      labelAttributes: [],
+      controlComponents: [],
+      assert: 'both',
+      depth: 25
+    }],
+
     // require HTML element's lang prop to be valid
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
     'jsx-a11y/lang': 'error',
+
+    // media elements must have captions
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md
+    'jsx-a11y/media-has-caption': ['error', {
+      audio: [],
+      video: [],
+      track: [],
+    }],
+
+    // require that mouseover/out come with focus/blur, for keyboard-only users
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
+    'jsx-a11y/mouse-events-have-key-events': 'error',
+
+    // Prevent use of `accessKey`
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
+    'jsx-a11y/no-access-key': 'error',
+
+    // prohibit autoFocus prop
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md
+    'jsx-a11y/no-autofocus': ['error', { ignoreNonDOM: true }],
 
     // prevent distracting elements, like <marquee> and <blink>
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md
@@ -144,25 +158,10 @@ module.exports = {
       elements: ['marquee', 'blink'],
     }],
 
-    // only allow <th> to have the "scope" attr
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
-    'jsx-a11y/scope': 'error',
-
-    // require onClick be accompanied by onKeyUp/onKeyDown/onKeyPress
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md
-    'jsx-a11y/click-events-have-key-events': 'error',
-
-    // Enforce that DOM elements without semantic behavior not have interaction handlers
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
-    'jsx-a11y/no-static-element-interactions': ['error', {
-      handlers: [
-        'onClick',
-        'onMouseDown',
-        'onMouseUp',
-        'onKeyPress',
-        'onKeyDown',
-        'onKeyUp',
-      ]
+    // WAI-ARIA roles should not be used to convert an interactive element to non-interactive
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': ['error', {
+      tr: ['none', 'presentation'],
     }],
 
     // A non-interactive element does not support event handlers (mouse and key handlers)
@@ -176,41 +175,6 @@ module.exports = {
         'onKeyDown',
         'onKeyUp',
       ]
-    }],
-
-    // ensure emoji are accessible
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
-    // disabled; rule is deprecated
-    'jsx-a11y/accessible-emoji': 'off',
-
-    // elements with aria-activedescendant must be tabbable
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md
-    'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
-
-    // ensure iframe elements have a unique title
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md
-    'jsx-a11y/iframe-has-title': 'error',
-
-    // prohibit autoFocus prop
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md
-    'jsx-a11y/no-autofocus': ['error', { ignoreNonDOM: true }],
-
-    // ensure HTML elements do not specify redundant ARIA roles
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
-    'jsx-a11y/no-redundant-roles': 'error',
-
-    // media elements must have captions
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md
-    'jsx-a11y/media-has-caption': ['error', {
-      audio: [],
-      video: [],
-      track: [],
-    }],
-
-    // WAI-ARIA roles should not be used to convert an interactive element to non-interactive
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md
-    'jsx-a11y/no-interactive-element-to-noninteractive-role': ['error', {
-      tr: ['none', 'presentation'],
     }],
 
     // WAI-ARIA roles should not be used to convert a non-interactive element to interactive
@@ -230,18 +194,58 @@ module.exports = {
       roles: ['tabpanel'],
     }],
 
-    // ensure <a> tags are valid
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/0745af376cdc8686d85a361ce36952b1fb1ccf6e/docs/rules/anchor-is-valid.md
-    'jsx-a11y/anchor-is-valid': ['error', {
-      components: ['Link'],
-      specialLink: ['to'],
-      aspects: ['noHref', 'invalidHref', 'preferButton'],
+    // require onBlur instead of onChange
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md
+    'jsx-a11y/no-onchange': 'off',
+
+    // ensure HTML elements do not specify redundant ARIA roles
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
+    'jsx-a11y/no-redundant-roles': 'error',
+
+    // Enforce that DOM elements without semantic behavior not have interaction handlers
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
+    'jsx-a11y/no-static-element-interactions': ['error', {
+      handlers: [
+        'onClick',
+        'onMouseDown',
+        'onMouseUp',
+        'onKeyPress',
+        'onKeyDown',
+        'onKeyUp',
+      ]
     }],
 
-    // Ensure the autocomplete attribute is correct and suitable for the form field it is used with
-    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/29c68596b15c4ff0a40daae6d4a2670e36e37d35/docs/rules/autocomplete-valid.md
-    'jsx-a11y/autocomplete-valid': ['off', {
-      inputComponents: [],
+    // Enforce that elements with ARIA roles must have all required attributes
+    // for that role.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
+    'jsx-a11y/role-has-required-aria-props': 'error',
+
+    // Enforce that elements with explicit or implicit roles defined contain
+    // only aria-* properties supported by that role.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
+    'jsx-a11y/role-supports-aria-props': 'error',
+
+    // only allow <th> to have the "scope" attr
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
+    'jsx-a11y/scope': 'error',
+
+    // Enforce tabIndex value is not greater than zero.
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
+    'jsx-a11y/tabindex-no-positive': 'error',
+
+    // ----------------------------------------------------
+    // Rules that no longer exist in eslint-plugin-jsx-a11y
+    // ----------------------------------------------------
+
+    // require that JSX labels use "htmlFor"
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
+    // deprecated: replaced by `label-has-associated-control` rule
+    'jsx-a11y/label-has-for': ['off', {
+      components: [],
+      required: {
+        every: ['nesting', 'id'],
+      },
+      allowChildren: false,
     }],
   },
 };

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -540,6 +540,11 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/e2eaadae316f9506d163812a09424eb42698470a/docs/rules/jsx-no-constructed-context-values.md
     // TODO: enable, semver-minor
     'react/jsx-no-constructed-context-values': 'off',
+
+    // Prevent creating unstable components inside components
+    // https://github.com/yannickcr/eslint-plugin-react/blob/c2a790a3472eea0f6de984bdc3ee2a62197417fb/docs/rules/no-unstable-nested-components.md
+    // TODO: enable, semver-major
+    'react/no-unstable-nested-components': 'off',
   },
 
   settings: {


### PR DESCRIPTION
The ordering of the rules are currently not alphabetical, which can make it hard to tell whether there are rules missing or what's set for each rule from eslint-plugin-jsx-a11y. 

This change alphabetizes the list so it's easier to compare to the [list of supported rules](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#supported-rules)