### PR TITLE
Update imports.js

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -83,6 +83,7 @@ module.exports = {
         '**/vue.config.js', // vue-cli config
         '**/webpack.config.js', // webpack config
         '**/webpack.config.*.js', // webpack config
+        '**/webpack.*.js', // webpack config
         '**/rollup.config.js', // rollup config
         '**/rollup.config.*.js', // rollup config
         '**/gulpfile.js', // gulp config


### PR DESCRIPTION
Added the glob `**/webpack.*.js` to `import/no-extraneous-dependencies` rule to prevent errors when importing dev dependencies to files like `webpack.dev.js`, `webpack.prod.js` and `webpack.common.js`. More info here: https://webpack.js.org/guides/production/