### PR TITLE
Added period to 4.4 for formatting consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Other Style Guides
 
   <a name="arrays--from"></a>
   <a name="arrays--from-iterable"></a><a name="4.4"></a>
-  - [4.4](#arrays--from-iterable) To convert an iterable object to an array, use spreads `...` instead of [`Array.from`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+  - [4.4](#arrays--from-iterable) To convert an iterable object to an array, use spreads `...` instead of [`Array.from`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
 
     ```javascript
     const foo = document.querySelectorAll('.foo');


### PR DESCRIPTION
In the README, whenever there's a list item that ends in a code quote that has an inline link (like the 'Array.from' at the end of 4.4) there's never a period at the end. Formatting examples of this are: 4.1, 4.7, 5.1, 5.2, 6.1, etc.