### PR TITLE
Change "Enforce" to "Avoid" for 19.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2887,7 +2887,7 @@ Other Style Guides
     ```
 
   <a name="whitespace--computed-property-spacing"></a>
-  - [19.16](#whitespace--computed-property-spacing) Enforce spacing inside of computed property brackets. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
+  - [19.16](#whitespace--computed-property-spacing) Avoid spaces inside of computed property brackets. eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
 
     ```javascript
     // bad


### PR DESCRIPTION
This change adds clarity and creates consistency with 19.15 & 19.17 - see #1946. Per the discussion in issue #2127, this "enforce" means to "avoid".

Fixes #2127.