### PR TITLE
fix: add new line after list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Other Style Guides
     - `symbol`
     - `bigint`
 
+    &nbsp;
     ```javascript
     const foo = 1;
     let bar = foo;
@@ -91,6 +92,7 @@ Other Style Guides
     - `array`
     - `function`
 
+    &nbsp;
     ```javascript
     const foo = [1, 2];
     const bar = foo;


### PR DESCRIPTION
This Just adds a new line after list in this markdown. 

![newline](https://user-images.githubusercontent.com/30781942/132595357-77562fa0-2dd8-4544-a1cc-036651367ee8.png)
