### PR TITLE
Improve function-paren-newline with multiline-arguments option

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "confusing-browser-globals": "^1.0.10",
     "object.assign": "^4.1.2",
-    "object.entries": "^1.1.4"
+    "object.entries": "^1.1.4",
+    "semver": "^6.3.0"
   }
 }

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -1,3 +1,6 @@
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
+
 module.exports = {
   rules: {
     // enforce line breaks after opening and before closing array brackets
@@ -101,9 +104,9 @@ module.exports = {
     // TODO: enable
     'func-style': ['off', 'expression'],
 
-    // enforce consistent line breaks inside function parentheses
+    // require line breaks inside function parentheses if there are line breaks between parameters
     // https://eslint.org/docs/rules/function-paren-newline
-    'function-paren-newline': ['error', 'consistent'],
+    'function-paren-newline': ['error', semver.satisfies(eslintPkg.version, '>= 6') ? 'multiline-arguments' : 'consistent'],
 
     // Blacklist certain identifiers to prevent them being used
     // https://eslint.org/docs/rules/id-blacklist


### PR DESCRIPTION
Related to #1731. Options change provides better adherence  to [7.15](https://github.com/airbnb/javascript#functions--signature-invocation-indentation).