### PR TITLE
Explain why rule `react/jsx-key` is turned off

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -53,20 +53,20 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "@babel/runtime": "^7.14.6",
+    "@babel/runtime": "^7.15.4",
     "babel-preset-airbnb": "^4.5.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-find-rules": "^3.6.1",
-    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-import": "^2.24.2",
     "in-publish": "^2.0.1",
     "safe-publish-latest": "^1.1.4",
-    "tape": "^5.2.2"
+    "tape": "^5.3.1"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-    "eslint-plugin-import": "^2.23.4"
+    "eslint-plugin-import": "^2.24.2"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -59,24 +59,24 @@
     "object.entries": "^1.1.4"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.14.6",
+    "@babel/runtime": "^7.15.4",
     "babel-preset-airbnb": "^4.5.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-find-rules": "^3.6.1",
-    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.0.1 || ^3 || ^2.3.0 || ^1.7.0",
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^1.1.4",
-    "tape": "^5.2.2"
+    "tape": "^5.3.1"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.0.1 || ^3 || ^2.3.0 || ^1.7.0"

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -67,7 +67,7 @@
     "eslint-find-rules": "^3.6.1",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react": "^7.26.0",
     "eslint-plugin-react-hooks": "^4.0.1 || ^3 || ^2.3.0 || ^1.7.0",
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
@@ -78,7 +78,7 @@
     "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.23.1",
+    "eslint-plugin-react": "^7.26.0",
     "eslint-plugin-react-hooks": "^4.0.1 || ^3 || ^2.3.0 || ^1.7.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -91,6 +91,7 @@ module.exports = {
 
     // Validate JSX has key prop when in array or iterator
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+    // Turned off because it has too many false positives
     'react/jsx-key': 'off',
 
     // Limit maximum of props on a single line in JSX

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -545,6 +545,16 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/c2a790a3472eea0f6de984bdc3ee2a62197417fb/docs/rules/no-unstable-nested-components.md
     // TODO: enable, semver-major
     'react/no-unstable-nested-components': 'off',
+
+    // Enforce that namespaces are not used in React elements
+    // https://github.com/yannickcr/eslint-plugin-react/blob/8785c169c25b09b33c95655bf508cf46263bc53f/docs/rules/no-namespace.md
+    // TODO: enable, semver-minor
+    'react/no-namespace': 'off',
+
+    // Prefer exact proptype definitions
+    // https://github.com/yannickcr/eslint-plugin-react/blob/8785c169c25b09b33c95655bf508cf46263bc53f/docs/rules/prefer-exact-props.md
+    // TODO: enable, semver-major, just in case
+    'react/prefer-exact-props': 'off',
   },
 
   settings: {


### PR DESCRIPTION
~~As you probably are aware, [one should define a `key` property when rendering a list in JSX](https://reactjs.org/docs/lists-and-keys.html#keys). And there is also [the ESLint rule `react/jsx-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) for that, so I am really surprised that this rule is not turned on by default in the AirBnB ESLint settings.~~

As [explained by @ljharb](https://github.com/airbnb/javascript/pull/2474#discussion_r715661547) the rule `react/jsx-key` is turned off on purpose. This adds the explanation for that, so that others also find this easier to understand.
 