### PR TITLE
[eslint config] set `namedComponents` option to match style guide

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -376,6 +376,11 @@ module.exports = {
     // https://eslint.org/docs/rules/prefer-named-capture-group
     'prefer-named-capture-group': 'off',
 
+    // Prefer Object.hasOwn() over Object.prototype.hasOwnProperty.call()
+    // https://eslint.org/docs/rules/prefer-object-has-own
+    // TODO: semver-major: enable thus rule, once eslint v8.5.0 is required
+    'prefer-object-has-own': 'off',
+
     // https://eslint.org/docs/rules/prefer-regex-literals
     'prefer-regex-literals': ['error', {
       disallowRedundantWrapping: true,

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -79,7 +79,7 @@
     "eslint-find-rules": "^4.0.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-react": "^7.27.1",
+    "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
@@ -90,7 +90,7 @@
     "eslint": "^7.32.0 || ^8.2.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-react": "^7.27.1",
+    "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -524,9 +524,8 @@ module.exports = {
 
     // Enforce a specific function type for function components
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md
-    // TODO: investigate if setting namedComponents to expression vs declaration is problematic
     'react/function-component-definition': ['error', {
-      namedComponents: 'function-expression',
+      namedComponents: ['function-declaration', 'function-expression'],
       unnamedComponents: 'function-expression',
     }],
 


### PR DESCRIPTION
Change the `namedComponents` option to `function-declaration` to match what the style guide requires.

https://github.com/airbnb/javascript/commit/019e0f7e07477e85249e1d584f22773120c41b91#r60060792

Closes #2505