### PR TITLE
[readme] update blocks 16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2144,8 +2144,8 @@ Other Style Guides
 
 ## Blocks
 
-  <a name="blocks--braces"></a><a name="16.1"></a>
-  - [16.1](#blocks--braces) Use braces with all multiline blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
+  <a name="blocks--braces"></a>
+  - [16.1](#blocks--braces) Use braces with `if`, `else`, `while`, `do-while`, and `for` statements when writing multiline blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
 
     ```javascript
     // bad
@@ -2161,11 +2161,15 @@ Other Style Guides
     }
 
     // bad
-    function foo() { return false; }
+    while (foo)
+      bar();
 
     // good
-    function bar() {
-      return false;
+    while (foo) bar();
+
+    // good
+    while (foo) {
+      bar();
     }
     ```
 


### PR DESCRIPTION
I gone through the eslint: `nonblock-statement-body-position` documentation where they didn't mention about the `function`  as block for this rule so, I removed the function example and clearly mention the block statements on which this rule implies.