### PR TITLE
Add Class Private Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,39 @@ Other Style Guides
       }
     }
     ```
+    
+    <a name="classes--private-identifier"></a>
+  - [9.8](#classes--private-identifier) Class members should use `#` to mark them as private members. 
+
+    ```javascript
+    // bad
+    class Foo {
+      _bar() {
+        console.log('bar');
+      }
+    }
+    
+    // bad
+    class Foo {
+      bar_() {
+        console.log('bar');
+      }
+    }
+    
+    // bad
+    class Foo {
+      __bar__() {
+        console.log('bar');
+      }
+    }
+    
+    // good
+    class Foo {
+      #bar() {
+        console.log(this.bar);
+      }
+    }
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -3297,7 +3330,7 @@ Other Style Guides
   <a name="naming--leading-underscore"></a><a name="22.4"></a>
   - [23.4](#naming--leading-underscore) Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](https://eslint.org/docs/rules/no-underscore-dangle.html)
 
-    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won’t count as breaking, or that tests aren’t needed. tl;dr: if you want something to be “private”, it must not be observably present.
+    > Why? ECMA2022 introduced [`#` as the private identifier](https://tc39.es/ecma262/#sec-static-semantics-privateboundidentifiers). Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won’t count as breaking, or that tests aren’t needed. tl;dr: if you want something to be “private”, it must not be observably present.
 
     ```javascript
     // bad
@@ -3306,7 +3339,7 @@ Other Style Guides
     this._firstName = 'Panda';
 
     // good
-    this.firstName = 'Panda';
+    this.firstName = 'Panda'; 
 
     // good, in environments where WeakMaps are available
     // see https://kangax.github.io/compat-table/es6/#test-WeakMap


### PR DESCRIPTION
## Include Class Private Identifier 

ECMA2022 standardized the private identifier `#`. It marks class members as private.

#### Additional Section:

- 9.8 Class members should use `#` to mark them as private members.

#### Modified Section:

- 23.4 Do not use trailing or leading underscores.

#### References:

- [ECMAScript 2022 Language Specification](https://tc39.es/ecma262/#sec-static-semantics-privateboundidentifiers)
- [TC39 Proposal - Private methods and getter/setters for JavaScript classes](https://github.com/tc39/proposal-private-methods)
- [TC39 Proposal  - Class field declarations for JavaScript](https://github.com/tc39/proposal-class-fields)