### PR TITLE
[eslint-config] turn on no-direct-mutation-state

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -187,7 +187,7 @@ module.exports = {
 
     // Prevent direct mutation of this.state
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
-    'react/no-direct-mutation-state': 'off',
+    'react/no-direct-mutation-state': 'error',
 
     // Prevent usage of isMounted
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md


### PR DESCRIPTION
Mutating state directly is considered bad practice in react.js, it make our code hard to maintain and also cause some hidden bug, we should turn this rule on.