### PR TITLE
[eslint config] [imports] fix imports.js remove node_modules from imp…

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -24,7 +24,6 @@ module.exports = {
     'import/core-modules': [
     ],
     'import/ignore': [
-      'node_modules',
       '\\.(coffee|scss|css|less|hbs|svg|json)$',
     ],
   },


### PR DESCRIPTION
remove `node_module` from `packages/eslint-config-airbnb-base/rules/imports.js`

this pull request resolves the following issue: #2457 
