### PR TITLE
[eslint config] Prefer default arguments to default props

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -388,9 +388,11 @@ module.exports = {
     'react/no-array-index-key': 'error',
 
     // Enforce a defaultProps definition for every prop that is not a required prop
-    // https://github.com/jsx-eslint/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/require-default-props.md
+    // Enforce defaultArguments rather than defaultProps
+    // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
     'react/require-default-props': ['error', {
       forbidDefaultForRequired: true,
+      functions: 'defaultArguments',
     }],
 
     // Forbids using non-exported propTypes


### PR DESCRIPTION
defaultProps on function components is getting deprecated by React (see: [here](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#deprecate-defaultprops-on-function-components))

The official recommendation in future versions of React is to use ES6 default values for function components.

### Before

```js
Header.defaultProps = {
  currency: 'GBP',
};

export default function Header({ currency }) {
```

### After

```js
export default function Header({ currency = 'GBP' }) {
```