### PR TITLE
Better support for `test`, `tests`, and `spec` directories for `import/no-extraneous-dependencies` rule

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -70,9 +70,9 @@ module.exports = {
     // paths are treated both as absolute paths, and relative to process.cwd()
     'import/no-extraneous-dependencies': ['error', {
       devDependencies: [
-        'test/**', // tape, common npm pattern
-        'tests/**', // also common npm pattern
-        'spec/**', // mocha, rspec-like pattern
+        '**/test/**', // tape, common npm pattern
+        '**/tests/**', // also common npm pattern
+        '**/spec/**', // mocha, rspec-like pattern
         '**/__tests__/**', // jest pattern
         '**/__mocks__/**', // jest pattern
         'test.{js,jsx}', // repos with a single test file


### PR DESCRIPTION
Updates the globs for `test`, `tests`, and `spec` directories so that they will be picked up from anywhere in the project. This gets it to work identically to `__tests__`.

Right now the current rule will only pick up files in these directories if the directory is in the root of the project. If a project co-locates `test` directories with the source (ex: under `/src/foo/test/foo.test.js`), the rule does not take affect and you'll get linting errors when `require`ing or `import`ing dev dependencies.