### PR TITLE
fix: allow block comments with multiple *

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -510,7 +510,7 @@ module.exports = {
         markers: ['=', '!', '/'], // space here to support sprockets directives, slash for TS /// comments
       },
       block: {
-        exceptions: ['-', '+'],
+        exceptions: ['-', '+', '*'],
         markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
         balanced: true,
       }


### PR DESCRIPTION
Allow comments like:

```js
/**
 * Bla bla bla
 **/
```