### PR TITLE
[eslint config] [base] disable the deprecated `no-spaced-func` rule

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -351,7 +351,8 @@ module.exports = {
     ],
 
     // disallow space between function identifier and application
-    'no-spaced-func': 'error',
+    // deprecated in favor of func-call-spacing
+    'no-spaced-func': 'off',
 
     // disallow tab characters entirely
     'no-tabs': 'error',


### PR DESCRIPTION
This rule was deprecated since ESLint v3.3.0 and replaced by the
`func-call-spacing` rule.
https://eslint.org/docs/latest/rules/no-spaced-func

`func-call-spacing` was enabled in this package long ago:
https://github.com/airbnb/javascript/commit/27dcb99c6d80718946d10017144b2aa68bed8b9e

So there's no need for it to stay in the ruleset.

Besides, it is causing some tricky issues when overriding the rules for
TypeScript support (https://github.com/iamturns/eslint-config-airbnb-typescript/issues/246)