### PR TITLE
[editorial] convert example to use single instead of double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3131,7 +3131,7 @@ Other Style Guides
     });
 
     // good
-    const reaction = "No! That’s impossible!";
+    const reaction = 'No! That’s impossible!';
     (async function meanwhileOnTheFalcon() {
       // handle `leia`, `lando`, `chewie`, `r2`, `c3p0`
       // ...

--- a/packages/eslint-config-airbnb-base/rules/style.js
+++ b/packages/eslint-config-airbnb-base/rules/style.js
@@ -191,6 +191,13 @@ module.exports = {
       after: 'always',
     }],
 
+    // Require or disallow logical assignment logical operator shorthand
+    // https://eslint.org/docs/latest/rules/logical-assignment-operators
+    // TODO, semver-major: enable
+    'logical-assignment-operators': ['off', 'always', {
+      enforceForIfStatements: true,
+    }],
+
     // specify the maximum depth that blocks can be nested
     'max-depth': ['off', 4],
 


### PR DESCRIPTION
In Airbnb style;

[6.1](https://github.com/airbnb/javascript#strings--quotes) Use single quotes '' for strings. eslint: [quotes](https://eslint.org/docs/rules/quotes)