### PR TITLE
[actions] setting minimum token permissions for github actions

### DIFF
--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -2,6 +2,9 @@ name: 'Tests: pretest/posttest'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   pretest:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,9 @@ name: 'Tests: node.js'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,8 +2,14 @@ name: Automatic Rebase
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      contents: write  # for ljharb/rebase to push code to rebase
+      pull-requests: read  # for ljharb/rebase to get info about PR
     name: "Automatic Rebase"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -2,8 +2,13 @@ name: Require “Allow Edits”
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      pull-requests: read  # for ljharb/require-allow-edits to check 'allow edits' on PR
     name: "Require “Allow Edits”"
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR sets minimum token permission for all workflow files in the repository. Currently, GitHub token has elevated access as demonstrated by the following GitHub Actions workflow run that was executed 13 hours ago:
https://github.com/airbnb/javascript/actions/runs/3356458922/jobs/5561538946#step:1:19

In addition to this PR, if you have repo admin access, then you should consider setting the following permission so that new workflow files will default to read-only permissions
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>