### PR TITLE
[guide] Add `Object.hasOwn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Other Style Guides
     /* or */
     import has from 'has'; // https://www.npmjs.com/package/has
     console.log(has(object, key));
+    /* or */
+    console.log(Object.hasOwn(object, key)); // https://www.npmjs.com/package/object.hasown
     ```
 
   <a name="objects--rest-spread"></a>


### PR DESCRIPTION
Hello,

18.2 Use // for single line comments. Place single line comments on a newline above the subject of the comment. Put an empty line before the comment unless it’s on the first line of a block.
18.1 Use /** ... */ for multiline comments.

For hasOwn;
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn