### PR TITLE
added rule import/no-extraneous-dependencies to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,23 @@ Other Style Guides
     import bar from './bar';
     import baz from './baz';
     ```
+  <a name="modules--import/no-extraneous-dependencies"></a><a name="10.3"></a>
+  - [10.11](#modules--import/no-extraneous-dependencies) Forbid the use of extraneous packages.
+  eslint: [`import/no-extraneous-dependencies`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md)
+
+    > Why? You should only allow modules that are declared in the package.json's dependencies, devDependencies, optionalDependencies, peerDependencies, or bundledDependencies to be imported and used within the project.
+
+    ```javascript
+    // bad
+    // Not declared in package,json - es6.js
+    import es6 from 'es6';
+    const es6 = require('es6');
+
+    // good
+    // Declared in package.json es6.js
+    import es6 from 'es6';
+    const es6 = require('es6');
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1468,8 +1468,11 @@ Other Style Guides
     import foo from './foo';
     import bar from './bar';
     import baz from './baz';
+
     ```
-  <a name="modules--import/no-extraneous-dependencies"></a><a name="10.3"></a>
+
+  <a name="modules--import/no-extraneous-dependencies"></a><a name="10.11"></a>
+
   - [10.11](#modules--import/no-extraneous-dependencies) Forbid the use of extraneous packages.
   eslint: [`import/no-extraneous-dependencies`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md)
 
@@ -1485,6 +1488,7 @@ Other Style Guides
     // Declared in package.json es6.js
     import es6 from 'es6';
     const es6 = require('es6');
+    
     ```
 
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -1480,7 +1480,7 @@ Other Style Guides
 
     ```javascript
     // bad
-    // Not declared in package,json - es6.js
+    // Not declared in package.json - es6.js
     import es6 from 'es6';
     const es6 = require('es6');
 


### PR DESCRIPTION
Added the eslint rule **import/no-extraneous-dependencies** to the modules section. Fixes #2727 