### PR TITLE
[readme] correct no-use-before-define justification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1964,7 +1964,7 @@ Other Style Guides
   <a name="no-use-before-define"></a>
   - [14.5](#no-use-before-define) Variables, classes, and functions should be defined before they can be used. eslint: [`no-use-before-define`](https://eslint.org/docs/latest/rules/no-use-before-define)
 
-    > Why? When variables, classes, or functions are declared before being used, it can harm readability since a reader won't know what a thing that's referenced is. It's much clearer for a reader to first encounter the source of a thing (whether imported from another module, or defined in the file) before encountering a use of the thing.
+    > Why? When variables, classes, or functions are declared after being used, it can harm readability since a reader won't know what a thing that's referenced is. It's much clearer for a reader to first encounter the source of a thing (whether imported from another module, or defined in the file) before encountering a use of the thing.
 
     ```javascript
     // bad


### PR DESCRIPTION
The recommendation is to declare the variables, classes and functions before. So the contrasting negative example should say after.