### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Other Style Guides
 ## Objects
 
   <a name="objects--no-new"></a><a name="3.1"></a>
-  - [3.1](#objects--no-new) Use the literal syntax for object creation. eslint: [`no-new-object`](https://eslint.org/docs/rules/no-new-object)
+  - [3.1](#objects--no-new) Use the literal syntax for object creation. eslint: [`no-object-constructor`](https://eslint.org/docs/latest/rules/no-object-constructor)
 
     ```javascript
     // bad


### PR DESCRIPTION
Since  ESLint v8.50.0 no-new-object is replaced by the no-object-constructor rule. (https://eslint.org/docs/latest/rules/no-new-object)