### PR TITLE
`no-return-await` Rule Deprecated

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -300,10 +300,6 @@ module.exports = {
     // https://eslint.org/docs/rules/no-return-assign
     'no-return-assign': ['error', 'always'],
 
-    // disallow redundant `return await`
-    // https://eslint.org/docs/rules/no-return-await
-    'no-return-await': 'error',
-
     // disallow use of `javascript:` urls.
     // https://eslint.org/docs/rules/no-script-url
     'no-script-url': 'error',


### PR DESCRIPTION
The `no-return-await` rule has been deprecated in ESLint v8.46.0.

https://eslint.org/docs/latest/rules/no-return-await