### PR TITLE
Allow importing dev dependencies in ESLint flat config file

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -92,7 +92,7 @@ module.exports = {
         '**/protractor.conf.*.js', // protractor config
         '**/karma.conf.js', // karma config
         '**/.eslintrc.js', // eslint config
-        '**/eslint.config.{js,mjs,cjs}' // eslint flat config
+        '**/eslint.config.js' // eslint flat config
       ],
       optionalDependencies: false,
     }],

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -91,7 +91,7 @@ module.exports = {
         '**/protractor.conf.js', // protractor config
         '**/protractor.conf.*.js', // protractor config
         '**/karma.conf.js', // karma config
-        '**/.eslintrc.js' // eslint config
+        '**/.eslintrc.js', // eslint config
         '**/eslint.config.{js,mjs,cjs}' // eslint flat config
       ],
       optionalDependencies: false,

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -92,6 +92,7 @@ module.exports = {
         '**/protractor.conf.*.js', // protractor config
         '**/karma.conf.js', // karma config
         '**/.eslintrc.js' // eslint config
+        '**/eslint.config.{js,mjs,cjs}' // eslint flat config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
Makes it match the behavior for the legacy `.eslintrc.js` config file.