### PR TITLE
Upd link to es5 and es6 compat table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3746,7 +3746,7 @@ Other Style Guides
 ## ECMAScript 5 Compatibility
 
   <a name="es5-compat--kangax"></a><a name="26.1"></a>
-  - [27.1](#es5-compat--kangax) Refer to [Kangax](https://twitter.com/kangax/)’s ES5 [compatibility table](https://kangax.github.io/es5-compat-table/).
+  - [27.1](#es5-compat--kangax) Refer to [Kangax](https://twitter.com/kangax/)’s ES5 [compatibility table](https://compat-table.github.io/compat-table/es5/).
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
The old links are dead. The current link base path for compat table (https://kangax.github.io/compat-table/) is redirecting to https://compat-table.github.io/compat-table/