### PR TITLE
Provide example of mid-variable acronym naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3521,7 +3521,7 @@ Other Style Guides
     ];
 
     // also good
-    const httpRequests = [
+    const httpUrlRequests = [
       // ...
     ];
 


### PR DESCRIPTION
Technically 23.9 says "Acronyms and initialisms should always be all uppercased, or all lowercased", however some counterexamples came up during a recent code review.

Counterexample: a variable that captures a GHE (GitHub Enterprise) API (Application Programming Interface) URL (Uniform Resource Locator) in the current rules can be (if all acronyms were to be used):

* `GHEAPIURL` or
* `gheapiurl`

but it seems reasonable to allow:

* `gheApiUrl`

based on the spirit of "readability" (making the word boundaries clearer).

So I'm just adding an example in hopes of not really needing to change the rule but still making sense.