### PR TITLE
remove object.entries dependency

### DIFF
--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -68,26 +68,26 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
-    "@babel/runtime": "^7.22.6",
+    "@babel/runtime": "^7.23.9",
     "babel-preset-airbnb": "^4.5.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^7.32.0 || ^8.2.0",
     "eslint-find-rules": "^4.1.0",
-    "eslint-plugin-import": "^2.28.0",
+    "eslint-plugin-import": "^2.29.1",
     "in-publish": "^2.0.1",
     "safe-publish-latest": "^2.0.0",
-    "tape": "^5.6.6"
+    "tape": "^5.7.4"
   },
   "peerDependencies": {
     "eslint": "^7.32.0 || ^8.2.0",
-    "eslint-plugin-import": "^2.28.0"
+    "eslint-plugin-import": "^2.29.1"
   },
   "engines": {
     "node": "^10.12.0 || >=12.0.0"
   },
   "dependencies": {
     "confusing-browser-globals": "^1.0.11",
-    "object.entries": "^1.1.6"
+    "object.entries": "^1.1.7"
   }
 }

--- a/packages/eslint-config-airbnb-base/package.json
+++ b/packages/eslint-config-airbnb-base/package.json
@@ -87,7 +87,6 @@
     "node": "^10.12.0 || >=12.0.0"
   },
   "dependencies": {
-    "confusing-browser-globals": "^1.0.11",
-    "object.entries": "^1.1.7"
+    "confusing-browser-globals": "^1.0.11"
   }
 }

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -217,6 +217,11 @@ module.exports = {
     // https://eslint.org/docs/rules/no-nonoctal-decimal-escape
     'no-nonoctal-decimal-escape': 'error',
 
+    // Disallow calls to the Object constructor without an argument
+    // https://eslint.org/docs/latest/rules/no-object-constructor
+    // TODO: enable, semver-major
+    'no-object-constructor': 'off',
+
     // disallow use of (old style) octal literals
     // https://eslint.org/docs/rules/no-octal
     'no-octal': 'error',

--- a/packages/eslint-config-airbnb-base/whitespace-async.js
+++ b/packages/eslint-config-airbnb-base/whitespace-async.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const { isArray } = Array;
+const { entries } = Object;
 const { ESLint } = require('eslint');
 
 const baseConfig = require('.');
@@ -8,7 +10,7 @@ const whitespaceRules = require('./whitespaceRules');
 const severities = ['off', 'warn', 'error'];
 
 function getSeverity(ruleConfig) {
-  if (Array.isArray(ruleConfig)) {
+  if (isArray(ruleConfig)) {
     return getSeverity(ruleConfig[0]);
   }
   if (typeof ruleConfig === 'number') {
@@ -25,13 +27,13 @@ async function onlyErrorOnRules(rulesToError, config) {
   });
   const baseRules = (await cli.calculateConfigForFile(require.resolve('./'))).rules;
 
-  Object.entries(baseRules).forEach((rule) => {
+  entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
     const severity = getSeverity(ruleConfig);
 
     if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
-      if (Array.isArray(ruleConfig)) {
+      if (isArray(ruleConfig)) {
         errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
       } else if (typeof ruleConfig === 'number') {
         errorsOnly.rules[ruleName] = 1;

--- a/packages/eslint-config-airbnb-base/whitespace-async.js
+++ b/packages/eslint-config-airbnb-base/whitespace-async.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const entries = require('object.entries');
 const { ESLint } = require('eslint');
 
 const baseConfig = require('.');
@@ -26,7 +25,7 @@ async function onlyErrorOnRules(rulesToError, config) {
   });
   const baseRules = (await cli.calculateConfigForFile(require.resolve('./'))).rules;
 
-  entries(baseRules).forEach((rule) => {
+  Object.entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
     const severity = getSeverity(ruleConfig);

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -4,7 +4,6 @@ const { CLIEngine } = require('eslint');
 
 if (CLIEngine) {
   /* eslint no-inner-declarations: 0 */
-  const entries = require('object.entries');
   const whitespaceRules = require('./whitespaceRules');
 
   const baseConfig = require('.');
@@ -26,7 +25,7 @@ if (CLIEngine) {
     const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
     const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 
-    entries(baseRules).forEach((rule) => {
+    Object.entries(baseRules).forEach((rule) => {
       const ruleName = rule[0];
       const ruleConfig = rule[1];
       const severity = getSeverity(ruleConfig);

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -1,5 +1,7 @@
 /* eslint global-require: 0 */
 
+const { isArray } = Array;
+const { entries } = Object;
 const { CLIEngine } = require('eslint');
 
 if (CLIEngine) {
@@ -11,7 +13,7 @@ if (CLIEngine) {
   const severities = ['off', 'warn', 'error'];
 
   function getSeverity(ruleConfig) {
-    if (Array.isArray(ruleConfig)) {
+    if (isArray(ruleConfig)) {
       return getSeverity(ruleConfig[0]);
     }
     if (typeof ruleConfig === 'number') {
@@ -25,13 +27,13 @@ if (CLIEngine) {
     const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
     const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 
-    Object.entries(baseRules).forEach((rule) => {
+    entries(baseRules).forEach((rule) => {
       const ruleName = rule[0];
       const ruleConfig = rule[1];
       const severity = getSeverity(ruleConfig);
 
       if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
-        if (Array.isArray(ruleConfig)) {
+        if (isArray(ruleConfig)) {
           errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
         } else if (typeof ruleConfig === 'number') {
           errorsOnly.rules[ruleName] = 1;

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -67,29 +67,29 @@
   "homepage": "https://github.com/airbnb/javascript",
   "dependencies": {
     "eslint-config-airbnb-base": "^15.0.0",
-    "object.entries": "^1.1.6"
+    "object.entries": "^1.1.7"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.22.6",
+    "@babel/runtime": "^7.23.9",
     "babel-preset-airbnb": "^4.5.0",
     "babel-tape-runner": "^3.0.0",
     "eclint": "^2.8.1",
     "eslint": "^7.32.0 || ^8.2.0",
     "eslint-find-rules": "^4.1.0",
-    "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-react": "^7.33.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "in-publish": "^2.0.1",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^2.0.0",
-    "tape": "^5.6.6"
+    "tape": "^5.7.4"
   },
   "peerDependencies": {
     "eslint": "^7.32.0 || ^8.2.0",
-    "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-react": "^7.33.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0"
   },
   "engines": {

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -66,8 +66,7 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "dependencies": {
-    "eslint-config-airbnb-base": "^15.0.0",
-    "object.entries": "^1.1.7"
+    "eslint-config-airbnb-base": "^15.0.0"
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/eslint-config-airbnb/whitespace-async.js
+++ b/packages/eslint-config-airbnb/whitespace-async.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const { isArray } = Array;
+const { entries } = Object;
 const { ESLint } = require('eslint');
 
 const baseConfig = require('.');
@@ -8,7 +10,7 @@ const whitespaceRules = require('./whitespaceRules');
 const severities = ['off', 'warn', 'error'];
 
 function getSeverity(ruleConfig) {
-  if (Array.isArray(ruleConfig)) {
+  if (isArray(ruleConfig)) {
     return getSeverity(ruleConfig[0]);
   }
   if (typeof ruleConfig === 'number') {
@@ -25,13 +27,13 @@ async function onlyErrorOnRules(rulesToError, config) {
   });
   const baseRules = (await cli.calculateConfigForFile(require.resolve('./'))).rules;
 
-  Object.entries(baseRules).forEach((rule) => {
+  entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
     const severity = getSeverity(ruleConfig);
 
     if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
-      if (Array.isArray(ruleConfig)) {
+      if (isArray(ruleConfig)) {
         errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
       } else if (typeof ruleConfig === 'number') {
         errorsOnly.rules[ruleName] = 1;

--- a/packages/eslint-config-airbnb/whitespace-async.js
+++ b/packages/eslint-config-airbnb/whitespace-async.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const entries = require('object.entries');
 const { ESLint } = require('eslint');
 
 const baseConfig = require('.');
@@ -26,7 +25,7 @@ async function onlyErrorOnRules(rulesToError, config) {
   });
   const baseRules = (await cli.calculateConfigForFile(require.resolve('./'))).rules;
 
-  entries(baseRules).forEach((rule) => {
+  Object.entries(baseRules).forEach((rule) => {
     const ruleName = rule[0];
     const ruleConfig = rule[1];
     const severity = getSeverity(ruleConfig);

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -4,7 +4,6 @@ const { CLIEngine } = require('eslint');
 
 if (CLIEngine) {
   /* eslint no-inner-declarations: 0 */
-  const entries = require('object.entries');
   const whitespaceRules = require('./whitespaceRules');
 
   const baseConfig = require('.');
@@ -26,7 +25,7 @@ if (CLIEngine) {
     const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
     const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 
-    entries(baseRules).forEach((rule) => {
+    Object.entries(baseRules).forEach((rule) => {
       const ruleName = rule[0];
       const ruleConfig = rule[1];
       const severity = getSeverity(ruleConfig);

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -1,5 +1,7 @@
 /* eslint global-require: 0 */
 
+const { isArray } = Array;
+const { entries } = Object;
 const { CLIEngine } = require('eslint');
 
 if (CLIEngine) {
@@ -11,7 +13,7 @@ if (CLIEngine) {
   const severities = ['off', 'warn', 'error'];
 
   function getSeverity(ruleConfig) {
-    if (Array.isArray(ruleConfig)) {
+    if (isArray(ruleConfig)) {
       return getSeverity(ruleConfig[0]);
     }
     if (typeof ruleConfig === 'number') {
@@ -25,13 +27,13 @@ if (CLIEngine) {
     const cli = new CLIEngine({ baseConfig: config, useEslintrc: false });
     const baseRules = cli.getConfigForFile(require.resolve('./')).rules;
 
-    Object.entries(baseRules).forEach((rule) => {
+    entries(baseRules).forEach((rule) => {
       const ruleName = rule[0];
       const ruleConfig = rule[1];
       const severity = getSeverity(ruleConfig);
 
       if (rulesToError.indexOf(ruleName) === -1 && severity === 'error') {
-        if (Array.isArray(ruleConfig)) {
+        if (isArray(ruleConfig)) {
           errorsOnly.rules[ruleName] = ['warn'].concat(ruleConfig.slice(1));
         } else if (typeof ruleConfig === 'number') {
           errorsOnly.rules[ruleName] = 1;


### PR DESCRIPTION
This removes the `object.entries` package and uses the widely available built-in native `Object.entries`.

Many years ago, you made these changes:

https://github.com/airbnb/javascript/blob/11ab37144b7f846f04f64a29b5beb6e00d74e84b/packages/eslint-config-airbnb-base/package.json#L86-L88

https://github.com/airbnb/javascript/blob/11ab37144b7f846f04f64a29b5beb6e00d74e84b/packages/eslint-config-airbnb/package.json#L95-L97

`Object.entries` has been available since node 7.x according to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#browser_compatibility).

This means the dependency is now entirely redundant it seems, unless we want to revert the various changes that lead us to eslint >=7 support being enforced.
