### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Other Style Guides
 
     ```javascript
     // bad
-    var a = 1;
-    var b = 2;
+    const a = 1;
+    const b = 2;
 
     // good
     const a = 1;
@@ -147,15 +147,20 @@ Other Style Guides
 
     ```javascript
     // const and let only exist in the blocks they are defined in.
-    {
-      let a = 1;
-      const b = 1;
-      var c = 1;
-    }
-    console.log(a); // ReferenceError
-    console.log(b); // ReferenceError
-    console.log(c); // Prints 1
-    ```
+   let a; // Declare a outside the block
+const b = 1; // Declare b with const
+
+{
+  a = 1; // Assign a value inside the block
+}
+
+var c = 1; // Declare c with var outside the block
+
+console.log(a); // Prints 1
+console.log(b); // Prints 1
+console.log(c); // Prints 1
+
+    
 
     In the above code, you can see that referencing `a` and `b` will produce a ReferenceError, while `c` contains the number. This is because `a` and `b` are block scoped, while `c` is scoped to the containing function.
 


### PR DESCRIPTION
let a = 1; declares a variable a with a value of 1 within a block scope using the let keyword. However, since a is declared within curly braces {}, it is scoped to that block and cannot be accessed outside of it. Hence, console.log(a); results in a ReferenceError.

const b = 1; declares a constant variable b with a value of 1 within the same block. Similarly, b is scoped to that block and cannot be accessed outside of it. Hence, console.log(b); also results in a ReferenceError.

var c = 1; declares a variable c with a value of 1 using the var keyword. Unlike let and const, var variables are function-scoped or globally scoped, but not block-scoped. Therefore, c is accessible outside of the block and its value 1 is printed when console.log(c); is executed.