### PR TITLE
feat!: use ecmaVersion latest

### DIFF
--- a/packages/eslint-config-airbnb-base/index.js
+++ b/packages/eslint-config-airbnb-base/index.js
@@ -10,7 +10,7 @@ module.exports = {
     './rules/strict',
   ].map(require.resolve),
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
   rules: {},


### PR DESCRIPTION
The following code is often used when using @eslint/eslintrc with `eslint-config-airbnb-base`:

```js
// mimic CommonJS variables -- not needed if using CommonJS
const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
```

However, `import.meta` is not supported in ecmaVersion: '2018'. This change allows users to be able to use it that way.