### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Other Style Guides
     ```
 
   <a name="arrays--push"></a><a name="4.2"></a>
-  - [4.2](#arrays--push) Use [Array#push](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/push) instead of direct assignment to add items to an array.
+  - [4.2](#arrays--push) Use [`Array.push`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/push) instead of direct assignment to add items to an array.
 
     ```javascript
     const someStack = [];


### PR DESCRIPTION
Hello,

I have fixed typo in 4.2 to better doc clarity. The ``#`` in the word block does not have any meaning, and is not used throughout the document. Thus, I wanted to suggest to change `Array#push` to `Array.push` so that it increases readability and matches existing wording style  such as 4.4's `Array.from` .

Thank you

cc. @ljharb  
