### PR TITLE
Fix crash in ESLint invocation with TIMING env set

### DIFF
--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -51,5 +51,11 @@ if (CLIEngine) {
   const path = require('path');
   const { execSync } = require('child_process');
 
-  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'))));
+  // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
+  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'), {
+    env: {
+      ...process.env,
+      TIMING: undefined,
+    }
+  })));
 }

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -51,5 +51,11 @@ if (CLIEngine) {
   const path = require('path');
   const { execSync } = require('child_process');
 
-  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'))));
+  // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
+  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'), {
+    env: {
+      ...process.env,
+      TIMING: undefined,
+    }
+  })));
 }


### PR DESCRIPTION
Fixes https://github.com/airbnb/javascript/issues/3045

Please see the linked issue for additional context. Here's copy-pasta of the report

> In [`/whitespace.js`](https://github.com/airbnb/javascript/blob/e6080c7beed96700a599e7d86f1517bdc8269366/packages/eslint-config-airbnb/whitespace.js#L54) a subprocess is launched to print out the rules in JSON and the JSON response is parsed.

> If ESLint is being run with `TIMING=1`, it prints how much time each rule takes, and because the linked child process invocation is forwarding the env as-is, it's json parsing will fail and the process breaks down.