### PR TITLE
fix: mistake in allowArrowFunction

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -109,7 +109,7 @@ module.exports = {
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
     'react/jsx-no-bind': ['error', {
       ignoreRefs: true,
-      allowArrowFunctions: true,
+      allowArrowFunctions: false,
       allowFunctions: false,
       allowBind: false,
       ignoreDOMComponents: true,


### PR DESCRIPTION
## What does this PR do?
This PR fixes the incorrection in allowArrowFuntion "true" to "false" in react.js.

Fixes #2255

![image](https://github.com/user-attachments/assets/ad36b8e1-1675-4828-8301-4ba5ac1a20e3)

##Type of change
Bug fix (non-breaking change which fixes an issues).

##How should this be tested?
-[]Go to react.js file
-[]Check the line no 112 that bug in allowArrowFunction "false"

##Mandatory Tasks

-[X] Make sure you have self-reviewed the code.A decent size PR without self-review might be rejected.
 