### PR TITLE
Bug Fix: Use HTML character entities to display JSX code

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -245,16 +245,16 @@ This style guide is mostly based on the standards that are currently prevalent i
 
     ```jsx
     // bad
-    <Foo bar='bar' />
+    &lt;Foo bar='bar' /&gt;
 
     // good
-    <Foo bar="bar" />
+    &lt;Foo bar="bar" /&gt;
 
     // bad
-    <Foo style={{ left: "20px" }} />
+    &lt;Foo style={{ left: "20px" }} /&gt;
 
     // good
-    <Foo style={{ left: '20px' }} />
+    &lt;Foo style={{ left: '20px' }} /&gt;
     ```
 
 ## Spacing


### PR DESCRIPTION
I have used HTML character entities such as "&lt;" and "&gt;" to display JSX code in a markdown format without being rendered as HTML.

And It works perfect in both cases.

In readme file:
![{F5E8D47C-64BC-43AB-B636-C59C641553B9}](https://github.com/user-attachments/assets/f8a31fc5-37f2-48c7-aac6-35b7b78ba292)

In webpage:
![{E60F6308-8CAB-4D57-8BF4-8F5AA6716862}](https://github.com/user-attachments/assets/99a10792-3e6b-42d8-99c5-0be226329990)
