### PR TITLE
fix whitespace module execSync under Windows with no shebang

### DIFF
--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -53,11 +53,10 @@ if (CLIEngine) {
   const isWindows = process.platform === 'win32';
   const whitespaceAsyncPath = path.join(__dirname, 'whitespace-async.js');
   const execSyncCommand = isWindows ? `node ${whitespaceAsyncPath}` : whitespaceAsyncPath;
-  const execSyncOptions = isWindows ? { windowsHide: true, stdio: 'inherit' } : {};
 
   // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
   module.exports = JSON.parse(String(execSync(execSyncCommand, {
-    ...execSyncOptions,
+    windowsHide: true,
     env: {
       ...process.env,
       TIMING: undefined,

--- a/packages/eslint-config-airbnb-base/whitespace.js
+++ b/packages/eslint-config-airbnb-base/whitespace.js
@@ -50,9 +50,14 @@ if (CLIEngine) {
 } else {
   const path = require('path');
   const { execSync } = require('child_process');
+  const isWindows = process.platform === 'win32';
+  const whitespaceAsyncPath = path.join(__dirname, 'whitespace-async.js');
+  const execSyncCommand = isWindows ? `node ${whitespaceAsyncPath}` : whitespaceAsyncPath;
+  const execSyncOptions = isWindows ? { windowsHide: true, stdio: 'inherit' } : {};
 
   // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
-  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'), {
+  module.exports = JSON.parse(String(execSync(execSyncCommand, {
+    ...execSyncOptions,
     env: {
       ...process.env,
       TIMING: undefined,

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -53,11 +53,10 @@ if (CLIEngine) {
   const isWindows = process.platform === 'win32';
   const whitespaceAsyncPath = path.join(__dirname, 'whitespace-async.js');
   const execSyncCommand = isWindows ? `node ${whitespaceAsyncPath}` : whitespaceAsyncPath;
-  const execSyncOptions = isWindows ? { windowsHide: true, stdio: 'inherit' } : {};
 
   // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
   module.exports = JSON.parse(String(execSync(execSyncCommand, {
-    ...execSyncOptions,
+    windowsHide: true,
     env: {
       ...process.env,
       TIMING: undefined,

--- a/packages/eslint-config-airbnb/whitespace.js
+++ b/packages/eslint-config-airbnb/whitespace.js
@@ -50,9 +50,14 @@ if (CLIEngine) {
 } else {
   const path = require('path');
   const { execSync } = require('child_process');
+  const isWindows = process.platform === 'win32';
+  const whitespaceAsyncPath = path.join(__dirname, 'whitespace-async.js');
+  const execSyncCommand = isWindows ? `node ${whitespaceAsyncPath}` : whitespaceAsyncPath;
+  const execSyncOptions = isWindows ? { windowsHide: true, stdio: 'inherit' } : {};
 
   // NOTE: ESLint adds runtime statistics to the output (so it's no longer JSON) if TIMING is set
-  module.exports = JSON.parse(String(execSync(path.join(__dirname, 'whitespace-async.js'), {
+  module.exports = JSON.parse(String(execSync(execSyncCommand, {
+    ...execSyncOptions,
     env: {
       ...process.env,
       TIMING: undefined,


### PR DESCRIPTION
fixes #2700

In case the eslint version is 8, `whitespace.js` file tries to execute `whitespace-async.js` file.
`whitespace-async.js` file starts with shebang header `#!/usr/bin/env node` which doesn't work under Windows.
It cannot be executed right away without definition of interpreter.
In case we try to execute it with `execSync` or any other fork tool it opens up a dialog for choosing a program to open the .js file.
It requires explicit definition of `node` interpreter at the place of execution.
`windowsHide` option prevents opening of `cmd` window during execution and it is ignored under non-Windows systems.

there is another PR which is outdated. made a fresh one