### PR TITLE
fix: Add type-annotations support to react/sort-comp

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -260,6 +260,7 @@ module.exports = {
         'instance-methods',
         'everything-else',
         'rendering',
+        'type-annotations',
       ],
       groups: {
         lifecycle: [


### PR DESCRIPTION
Closes #1922
Currently, react/sort-comp does not support type-annotations, which causes inconsistencies in projects using Flow or TypeScript. Adding this support aligns better with modern React development practices.
This PR adds support for type-annotations in the react/sort-comp ESLint rule. This is particularly useful for projects using Flow and TypeScript, allowing developers to maintain a consistent order for type annotations like props, state, and context.