### PR TITLE
Added cross platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A mostly reasonable approach to JavaScript.",
   "scripts": {
     "preinstall": "npm run install:config && npm run install:config:base",
-    "postinstall": "rm -rf node_modules/markdownlint-cli/node_modules/markdownlint",
+    "postinstall": "rimraf node_modules/markdownlint-cli/node_modules/markdownlint",
     "install:config": "cd packages/eslint-config-airbnb && npm prune && npm install",
     "install:config:base": "cd packages/eslint-config-airbnb-base && npm prune && npm install",
     "lint": "markdownlint --config linters/.markdownlint.json README.md */README.md",
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "markdownlint": "^0.29.0",
-    "markdownlint-cli": "^0.35.0"
+    "markdownlint-cli": "^0.35.0",
+    "rimraf": "^6.0.1"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the `postinstall` script to use `npx rimraf` instead of `rm -rf` for removing the `markdownlint` directory.

Ensures cross platform compatibility for Windows and Linux based systems