### PR TITLE
Update README.md, update an outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3932,7 +3932,7 @@ Other Style Guides
 **Podcasts**
 
   - [JavaScript Air](https://javascriptair.com/)
-  - [JavaScript Jabber](https://devchat.tv/js-jabber/)
+  - [JavaScript Jabber](https://topenddevs.com/podcasts/javascript-jabber)
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
devchat.tv changes their domain to topenddevs.com
I updated the redirected links to their current destination.