### PR TITLE
feat: add ESLint config for markdown linting with eslint-plugin-markdown

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+// eslint.config.js
+const markdown = require('eslint-plugin-markdown');
+
+module.exports = [
+  {
+    plugins: {
+      markdown,
+    },
+  },
+  {
+    files: ['**/*.md'],
+    processor: 'markdown/markdown',
+  },
+  {
+    files: ['**/*.md/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+    },
+    rules: {
+      semi: ['error', 'always'],
+      'no-unused-vars': 'warn',
+      'no-undef': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   },
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
+    "eslint": "^9.31.0",
+    "eslint-plugin-markdown": "^5.1.0",
     "markdownlint": "^0.29.0",
     "markdownlint-cli": "^0.35.0"
   }

--- a/packages/eslint-config-airbnb-base/rules/imports.js
+++ b/packages/eslint-config-airbnb-base/rules/imports.js
@@ -280,4 +280,23 @@ module.exports = {
     // TODO, semver-minor: enable
     'import/no-empty-named-blocks': 'off',
   },
+  plugins: ["markdown"],
+  overrides: [
+    {
+      // Step 2a: Extract code blocks from markdown
+      files: ["**/*.md"],
+      processor: "markdown/markdown"
+    },
+    {
+      // Step 2b: Apply JS rules to those code blocks
+      files: ["**/*.md/*.js"],
+      rules: {
+        // Allow console logs in docs
+        "no-console": "off",
+        // Don't bother with unresolved imports in examples
+        "import/no-unresolved": "off"
+      }
+    }
+    // ...other overrides or rules
+  ],
 };


### PR DESCRIPTION
Points to be noted:

- Some examples in the README are intentionally invalid (for illustration purposes).
- With this setup, we can start linting the "good" examples to ensure they stay clean and consistent.

Looking ahead:

- We can explore ways to skip linting the intentionally "bad" examples either by using eslint-disable comments or setting up smarter filters.