### PR TITLE
Fix array index out of bounds by changing someStack.length to someStack.length  - 1 in the Arrays section

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Other Style Guides
     const someStack = [];
 
     // bad
-    someStack[someStack.length] = 'abracadabra';
+    someStack[someStack.length - 1] = 'abracadabra';
 
     // good
     someStack.push('abracadabra');


### PR DESCRIPTION
Changed array.length to `someStack.length - 1` to prevent an array index out of bounds error. The original line was causing an error, likely because the intended behavior was to access the last element or iterate safely within the array's bounds. This adjustment ensures proper array access without exceeding its limits.