### PR TITLE
docs: add note about ESLint --ext for .jsx files (see eslint/eslint#1402)

### DIFF
--- a/packages/eslint-config-airbnb-base/README.md
+++ b/packages/eslint-config-airbnb-base/README.md
@@ -62,6 +62,16 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
 
 2. Add `"extends": "airbnb-base"` to your .eslintrc.
 
+> **Note**: ESLint only lints `.js` files by default.
+
+  If your project uses `.jsx` (or `.tsx` with TypeScript), you need to pass extensions to the CLI:
+
+  ```sh
+  eslint . --ext .js, .jsx, .mjs
+  ```
+
+  Without this, JSX-related rules will not apply to `.jsx` files.
+
 ### eslint-config-airbnb-base/legacy
 
 Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.

--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -58,6 +58,15 @@ If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslin
 
 2. Add `"extends": "airbnb"` to your `.eslintrc`
 
+> **Note**: ESLint only lints `.js` files by default.
+  If your project uses `.jsx` (or `.tsx` with TypeScript), you need to pass extensions to the CLI:
+
+  ```sh
+  eslint . --ext .js, .jsx, .mjs
+  ```
+
+  Without this, JSX-related rules will not apply to `.jsx` files.
+
 ### eslint-config-airbnb/hooks
 
 This entry point enables the linting rules for React hooks (requires v16.8+). To use, add `"extends": ["airbnb", "airbnb/hooks"]` to your `.eslintrc`.


### PR DESCRIPTION
By default, ESLint only lints `.js` files. This PR updates the README(s) to note
that users need to pass `--ext .js,.jsx` (or `.tsx` for TypeScript) when running
ESLint so that rules like `react/jsx-filename-extension` are applied correctly.

Also updated package.json scripts to demonstrate this usage.

Fixes #1402 