### PR TITLE
Switched markdownlint config to stable MD rule IDs

### DIFF
--- a/linters/.markdownlint.json
+++ b/linters/.markdownlint.json
@@ -1,155 +1,42 @@
 {
-  "comment": "Be explicit by listing every available rule. https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md",
-  "comment": "Note that there will be numeric gaps, not every MD number is implemented in markdownlint.",
-
-  "comment": "MD001: Header levels should only increment by one level at a time.",
-  "header-increment": true,
-
-  "comment": "MD002: First header should be a top level header.",
-  "first-header-h1": true,
-
-  "comment": "MD003: Header style: start with hashes.",
-  "header-style": {
-    "style": "atx"
-  },
-
-  "comment": "MD004: Unordered list style",
-  "ul-style": {
-    "style": "dash"
-  },
-
-  "comment": "MD005: Consistent indentation for list items at the same level.",
-  "list-indent": true,
-
-  "comment": "MD006: Consider starting bulleted lists at the beginning of the line.",
-  "ul-start-left": false,
-
-  "comment": "MD007: Unordered list indentation: 2 spaces.",
-  "ul-indent": {
-    "indent": 2,
-    "start_indented": true
-  },
-
-  "comment": "MD009: Disallow trailing spaces!",
-  "no-trailing-spaces": {
-    "br_spaces": 0,
-    "comment": "Empty lines inside list items should not be indented.",
-    "list_item_empty_lines": false
-  },
-
-  "comment": "MD010: No hard tabs, not even in code blocks.",
-  "no-hard-tabs": {
-    "code_blocks": true
-  },
-
-  "comment": "MD011: Prevent reversed link syntax",
-  "no-reversed-links": true,
-
-  "comment": "MD012: Disallow multiple consecutive blank lines.",
-  "no-multiple-blanks": {
-    "maximum": 1
-   },
-
-  "comment": "MD013: Line length",
-  "line-length": false,
-
-  "comment": "MD014: Disallow use of dollar signs($) before commands without showing output.",
-  "commands-show-output": true,
-
-  "comment": "MD018: Disallow space after hash on atx style header.",
-  "no-missing-space-atx": true,
-
-  "comment": "MD019: Disallow multiple spaces after hash on atx style header.",
-  "no-multiple-space-atx": true,
-
-  "comment": "MD020: No space should be inside hashes on closed atx style header.",
-  "no-missing-space-closed-atx": true,
-
-  "comment": "MD021: Disallow multiple spaces inside hashes on closed atx style header.",
-  "no-multiple-space-closed-atx": true,
-
-  "comment": "MD022: Headers should be surrounded by blank lines.",
-  "comment": "Some headers have preceding HTML anchors. Unfortunate that we have to disable this, as it otherwise catches a real problem that trips up some Markdown renderers",
-  "blanks-around-headers": false,
-
-  "comment": "MD023: Headers must start at the beginning of the line.",
-  "header-start-left": true,
-
-  "comment": "MD024: Disallow multiple headers with the same content.",
-  "no-duplicate-header": true,
-
-  "comment": "MD025: Disallow multiple top level headers in the same document.",
-  "comment": "Gotta have a matching closing brace at the end.",
-  "single-h1": false,
-
-  "comment": "MD026: Disallow trailing punctuation in header.",
-  "comment": "You must have a semicolon after the ending closing brace.",
-  "no-trailing-punctuation": {
-    "punctuation" : ".,:!?"
-  },
-  "comment": "MD027: Dissalow multiple spaces after blockquote symbol",
-  "no-multiple-space-blockquote": true,
-
-  "comment": "MD028: Blank line inside blockquote",
-  "comment": "Some 'Why?' and 'Why not?' blocks are separated by a blank line",
-  "no-blanks-blockquote": false,
-
-  "comment": "MD029: Ordered list item prefix",
-  "ol-prefix": {
-    "style": "one"
-  },
-
-  "comment": "MD030: Spaces after list markers",
-  "list-marker-space": {
-    "ul_single": 1,
-    "ol_single": 1,
-    "ul_multi": 1,
-    "ol_multi": 1
-  },
-
-  "comment": "MD031: Fenced code blocks should be surrounded by blank lines",
-  "blanks-around-fences": true,
-
-  "comment": "MD032: Lists should be surrounded by blank lines",
-  "comment": "Some lists have preceding HTML anchors. Unfortunate that we have to disable this, as it otherwise catches a real problem that trips up some Markdown renderers",
-  "blanks-around-lists": false,
-
-  "comment": "MD033: Disallow inline HTML",
-  "comment": "HTML is needed for explicit anchors",
-  "no-inline-html": false,
-
-  "comment": "MD034: No bare URLs should be used",
-  "no-bare-urls": true,
-
-  "comment": "MD035: Horizontal rule style",
-  "hr-style": {
-    "style": "consistent"
-  },
-
-  "comment": "MD036: Do not use emphasis instead of a header.",
-  "no-emphasis-as-header": false,
-
-  "comment": "MD037: Disallow spaces inside emphasis markers.",
-  "no-space-in-emphasis": true,
-
-  "comment": "MD038: Disallow spaces inside code span elements.",
-  "no-space-in-code": true,
-
-  "comment": "MD039: Disallow spaces inside link text.",
-  "no-space-in-links": true,
-
-  "comment": "MD040: Fenced code blocks should have a language specified.",
-  "fenced-code-language": true,
-
-  "comment": "MD041: First line in file should be a top level header.",
-  "first-line-h1": true,
-
-  "comment": "MD042: No empty links",
-  "no-empty-links": true,
-
-  "comment": "MD043: Required header structure.",
-  "required-headers": false,
-
-  "comment": "MD044: Proper names should have the correct capitalization.",
-  "proper-names": false
+  "MD001": true,
+  "MD002": true,
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "dash" },
+  "MD005": true,
+  "MD006": false,
+  "MD007": { "indent": 2, "start_indented": true },
+  "MD009": { "br_spaces": 0, "list_item_empty_lines": false },
+  "MD010": { "code_blocks": true },
+  "MD011": true,
+  "MD012": { "maximum": 1 },
+  "MD013": false,
+  "MD014": true,
+  "MD018": true,
+  "MD019": true,
+  "MD020": true,
+  "MD021": true,
+  "MD022": false,
+  "MD023": true,
+  "MD024": true,
+  "MD025": false,
+  "MD026": { "punctuation": ".,:!?" },
+  "MD027": true,
+  "MD028": false,
+  "MD029": { "style": "one" },
+  "MD030": { "ul_single": 1, "ol_single": 1, "ul_multi": 1, "ol_multi": 1 },
+  "MD031": true,
+  "MD032": false,
+  "MD033": false,
+  "MD034": true,
+  "MD035": { "style": "consistent" },
+  "MD036": false,
+  "MD037": true,
+  "MD038": true,
+  "MD039": true,
+  "MD040": true,
+  "MD041": true,
+  "MD042": true,
+  "MD043": false,
+  "MD044": false
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A mostly reasonable approach to JavaScript.",
   "scripts": {
     "preinstall": "npm run install:config && npm run install:config:base",
-    "postinstall": "rm -rf node_modules/markdownlint-cli/node_modules/markdownlint",
+    "postinstall": "rimraf node_modules/markdownlint-cli/node_modules/markdownlint",
     "install:config": "cd packages/eslint-config-airbnb && npm prune && npm install",
     "install:config:base": "cd packages/eslint-config-airbnb-base && npm prune && npm install",
     "lint": "markdownlint --config linters/.markdownlint.json README.md */README.md",
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/airbnb/javascript",
   "devDependencies": {
     "markdownlint": "^0.29.0",
-    "markdownlint-cli": "^0.35.0"
+    "markdownlint-cli": "^0.35.0",
+    "rimraf": "^5.0.5"
   }
 }


### PR DESCRIPTION
Made the install scripts Windows-friendly by replacing Unix-only rm -rf with cross-platform rimraf and adding rimraf as a dev dependency. Cleaned and modernized markdownlint configuration by switching to canonical MD rule IDs and removing extraneous comment keys, preserving original linting intent. Lint now runs reliably across environments without behavioral changes.
