### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+Airbnb has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full Code of Conduct text](https://airbnb.io/codeofconduct/) so that you can understand what actions will and will not be tolerated. Report violations to the maintainers of this project or to [opensource-conduct@airbnb.com](mailto:opensource-conduct@airbnb.com).
+
+Reports sent to [opensource-conduct@airbnb.com](mailto:opensource-conduct@airbnb.com) are received by Airbnb's open source code of conduct moderation team, which is composed of Airbnb employees. All communications are private and confidential.


### PR DESCRIPTION
Airbnb has adopted a [Code of Conduct](https://airbnb.io/codeofconduct/) that applies to all open source projects. This addition ensures project participants understand community standards and provides clear reporting mechanisms for violations.

Source is a copy from https://github.com/airbnb/swift/blob/master/CODE_OF_CONDUCT.md