### PR TITLE
Fix jsx-a11y/control-has-associated-label: ignore td/th

### DIFF
--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -82,6 +82,8 @@ module.exports = {
         'textarea',
         'tr',
         'video',
+        'td',
+        'th',
       ],
       ignoreRoles: [
         'grid',


### PR DESCRIPTION
Added `td` and `th` to `ignoreElements` for `jsx-a11y/control-has-associated-label` in order to get rid of false positives on non-interactive table elements.

Closes #3069