### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -53,7 +53,7 @@ jobs:
       - run: node -pe "require('eslint/package.json').version"
         name: 'eslint version'
       - run: npm run travis
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
 
   react:
     needs: [matrix]
@@ -77,7 +77,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -90,7 +90,7 @@ jobs:
       - run: npm install --no-save "eslint-plugin-react-hooks@${{ matrix.react-hooks }}"
         if: ${{ matrix.react-hooks > 0}}
       - run: npm run travis
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
 
   prepublish-base:
     name: 'prepublish tests (base config)'
@@ -109,7 +109,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
         with:
@@ -142,7 +142,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
         with:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: ljharb/rebase@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `codecov/codecov-action` from `v2` to `v5` in `.github/workflows/node.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/node-pretest.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/rebase.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/node.yml`
