### PR TITLE
Docs: clarify cases where traditional functions are preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,18 +955,16 @@ Other Style Guides
   >
   > **Prefer traditional functions when:**
   >
-  > - You rely on **function hoisting**, such as calling a function before its definition.
+  > - You are defining top-level, reusable functions rather than inline callbacks.
   > - You need a **dynamic `this` binding**, for example in object methods or DOM event handlers.
   > - You require access to the **`arguments` object**, which is not available in arrow functions.
   >
   > **Examples:**
   >
   > ```js
-  > // Function hoisting
-  > initialize();
-  >
-  > function initialize() {
-  >   // setup logic
+  > // Named function for reuse and clearer stack traces
+  > function formatUserName(user) {
+  >   return `${user.firstName} ${user.lastName}`;
   > }
   > ```
   >

--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ Other Style Guides
 
     > Why not? If you have a fairly complicated function, you might move that logic out into its own named function expression.
 
-  > **Note:** Arrow functions are intended primarily for short, anonymous callbacks.
+  > **Note:** Arrow functions are intended primarily for inline, anonymous callbacks.
   > Outside of these cases, prefer traditional function declarations or expressions
   > for clarity and consistency.
   >

--- a/README.md
+++ b/README.md
@@ -949,15 +949,18 @@ Other Style Guides
 
     > Why not? If you have a fairly complicated function, you might move that logic out into its own named function expression.
 
-  > **Note:** While arrow functions are recommended for anonymous callbacks, traditional
-  > function declarations or expressions are still preferred in certain scenarios where
-  > their behavior is more appropriate.
+  > **Note:** Arrow functions are intended primarily for short, anonymous callbacks.
+  > Outside of these cases, prefer traditional function declarations or expressions
+  > for clarity and consistency.
   >
-  > **Prefer traditional functions when:**
+  > **Use arrow functions only when:**
   >
-  > - You are defining top-level, reusable functions rather than inline callbacks.
-  > - You need a **dynamic `this` binding**, for example in object methods or DOM event handlers.
-  > - You require access to the **`arguments` object**, which is not available in arrow functions.
+  > - Defining inline callbacks (for example in `map`, `filter`, or event handlers).
+  > - A lexical `this` binding is explicitly desired.
+  >
+  > In other situations — such as defining reusable functions, object methods, or code
+  > that relies on a dynamic `this` value or the `arguments` object — prefer traditional
+  > functions.
   >
   > **Examples:**
   >
@@ -983,6 +986,7 @@ Other Style Guides
   >   return Array.from(arguments).reduce((total, value) => total + value, 0);
   > }
   > ```
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -949,6 +949,45 @@ Other Style Guides
 
     > Why not? If you have a fairly complicated function, you might move that logic out into its own named function expression.
 
+  > **Note:** While arrow functions are recommended for anonymous callbacks, traditional
+  > function declarations or expressions are still preferred in certain scenarios where
+  > their behavior is more appropriate.
+  >
+  > **Prefer traditional functions when:**
+  >
+  > - You rely on **function hoisting**, such as calling a function before its definition.
+  > - You need a **dynamic `this` binding**, for example in object methods or DOM event handlers.
+  > - You require access to the **`arguments` object**, which is not available in arrow functions.
+  >
+  > **Examples:**
+  >
+  > ```js
+  > // Function hoisting
+  > initialize();
+  >
+  > function initialize() {
+  >   // setup logic
+  > }
+  > ```
+  >
+  > ```js
+  > // Dynamic `this` binding (e.g. event handlers)
+  > const button = document.querySelector('button');
+  >
+  > button.addEventListener('click', function () {
+  >   this.classList.add('active');
+  > });
+  > ```
+  >
+  > ```js
+  > // Using the `arguments` object
+  > function sum() {
+  >   return Array.from(arguments).reduce((total, value) => total + value, 0);
+  > }
+  > ```
+
+
+
     ```javascript
     // bad
     [1, 2, 3].map(function (x) {


### PR DESCRIPTION
This PR adds a small clarification to the Arrow Functions section describing cases where traditional functions are still preferred, such as function hoisting, dynamic `this` binding, and use of the `arguments` object.

The goal is to improve clarity without changing the existing recommendation.
