### PR TITLE
fix: use single quotes in nested ternary bad example (section 15.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2133,8 +2133,8 @@ Other Style Guides
     ```javascript
     // bad
     const foo = maybe1 > maybe2
-      ? "bar"
-      : value1 > value2 ? "baz" : null;
+      ? 'bar'
+      : value1 > value2 ? 'baz' : null;
 
     // split into 2 separated ternary expressions
     const maybeNull = value1 > value2 ? 'baz' : null;


### PR DESCRIPTION
## Summary

Related to #3152

While investigating the semicolon consistency reported in issue #3152, I found a separate but related inconsistency: the `// bad` example in section **15.6 (Nested Ternaries)** uses double-quoted string literals (`"bar"`, `"baz"`), which contradicts section **6.1** of this same guide that requires single quotes for strings.

## Change

```diff
- const foo = maybe1 > maybe2
-   ? "bar"
-   : value1 > value2 ? "baz" : null;
+ const foo = maybe1 > maybe2
+   ? 'bar'
+   : value1 > value2 ? 'baz' : null;
```

The `// good` and `// better` examples immediately below already use single-quoted strings (`'baz'`, `'bar'`) consistently. This fixes the `// bad` example to match.

## Why

- Section 6.1 states: *"Use single quotes `''` for strings."* eslint: `quotes`
- The `// bad` example should demonstrate bad practice for the **one** specific rule being illustrated (nested ternaries), not introduce a separate unrelated violation (wrong quote style)
- Mixing double and single quotes in adjacent examples within the same section is confusing

## Scope

This is a two-line documentation fix. No logic changes, no new content.