### PR TITLE
docs: fix grammar in 'References' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Other Style Guides
       count += 1;
     }
 
-    // good, use the let.
+    // good, use let.
     let count = 1;
     if (true) {
       count += 1;


### PR DESCRIPTION
Changed '// good, use the let.' to '// good, use let.' for better phrasing in the References section.