### PR TITLE
fix: pin 10 unpinned action(s)

### DIFF
--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install lts/* && npm install'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       latest: ${{ steps.set-matrix.outputs.requireds }}
     steps:
-      - uses: ljharb/actions/node/matrix@main
+      - uses: ljharb/actions/node/matrix@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         id: set-matrix
         with:
           versionsAsRoot: true
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           before_install: cd "packages/${{ matrix.package }}"
@@ -50,7 +50,7 @@ jobs:
       - run: node -pe "require('eslint/package.json').version"
         name: 'eslint version'
       - run: npm run travis
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
 
   react:
     needs: [matrix]
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           before_install: cd "packages/${{ matrix.package }}"
@@ -87,7 +87,7 @@ jobs:
       - run: npm install --no-save "eslint-plugin-react-hooks@${{ matrix.react-hooks }}"
         if: ${{ matrix.react-hooks > 0}}
       - run: npm run travis
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
 
   prepublish-base:
     name: 'prepublish tests (base config)'
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install lts/* && npm install'
         with:
           before_install: cd "packages/${{ matrix.package }}"
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install lts/* && npm install'
         with:
           before_install: cd "packages/${{ matrix.package }}"

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -10,6 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: ljharb/rebase@master
+    - uses: ljharb/rebase@c6bd0a72b14dfaf76ad6a070029c8b4592d03eea # master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ljharb/require-allow-edits@main
+    - uses: ljharb/require-allow-edits@13f90bc8cc5de000f2b44a0e2c3a11d108e8cd9f # main


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/node-pretest.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/node.yml` | Pinned 7 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/rebase.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/require-allow-edits.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.